### PR TITLE
Fix homepage showing one static resource repeated 8 times

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,10 +5,11 @@ import { useEffect, useRef, useState, type ReactNode } from "react";
 import gsap from "gsap";
 import { useGSAP } from "@gsap/react";
 import { useLanguage } from "@/shared/ui/i18n";
+import { useResources } from "@/hooks/useResources";
+import { ResourceCard } from "@/modules/resources/components/ResourceCard";
 
 gsap.registerPlugin(useGSAP);
 
-type ResourceCard = { title: string; type: string; tone: string; icon: ReactNode; verified?: boolean; };
 type Stat = { value: string; label: string };
 
 function AnimatedCounter({ value, active, delay = 0 }: { value: string; active: boolean; delay?: number }) {
@@ -58,21 +59,6 @@ function HeroArtwork({ floatOne, floatTwo, starLine1, starLine2 }: { floatOne: s
   );
 }
 
-function ResourceTile({ resource, description, view, downloads, direction }: { resource: ResourceCard; description: string; view: string; downloads: string; direction: "rtl" | "ltr" }) {
-  return (
-    <article className="rounded-lg border border-[#ededed] bg-white p-5 text-start shadow-[0_8px_24px_rgba(15,23,42,0.03)] transition hover:-translate-y-1 hover:shadow-[0_14px_34px_rgba(15,23,42,0.07)]" dir={direction}>
-      <div className="mb-5 flex items-center justify-between">
-        {resource.verified ? <span className="flex h-9 w-9 items-center justify-center rounded-full bg-[#174f47] text-white"><svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><path d="M20 6 9 17l-5-5" /></svg></span> : <span />}
-        <span className={`inline-flex items-center gap-2 rounded-full px-3 py-2 text-xs font-bold ${resource.tone}`}>{resource.icon}{resource.type}</span>
-      </div>
-      <h3 className="text-xl font-black leading-8 text-black">{resource.title}</h3>
-      <p className="mt-3 text-sm leading-7 text-[#8c8c8c]">{description}</p>
-      <div className="mt-4 flex items-center justify-end gap-3 text-[11px] font-semibold text-[#b4b4b4]" dir="ltr"><span>CC-BY-SA-4.0</span><span>V3.0.0</span><span>{downloads}</span></div>
-      <Link href="/resources" className="mt-5 flex h-9 items-center justify-center gap-2 rounded-full bg-[#f7f7f7] text-sm font-bold text-black transition hover:bg-black hover:text-white">{view}</Link>
-    </article>
-  );
-}
-
 function SectionHeading({ children, direction }: { children: ReactNode; direction: "rtl" | "ltr" }) {
   return <div className="mb-6 flex items-center justify-between" dir={direction}><h2 className="text-3xl font-black text-black sm:text-4xl">{children}</h2><div className="hidden rounded-full bg-[#fafafa] px-4 py-2 text-[#c8c8c8] sm:flex"><span className="px-2">‹</span><span className="px-2">›</span></div></div>;
 }
@@ -85,13 +71,10 @@ export default function HomePage() {
   const { t, direction } = useLanguage();
   const home = t.home;
 
-  const resources: ResourceCard[] = home.hero.categories.slice(0, 4).map((type, index) => ({
-    title: home.resourceCard.title,
-    type,
-    tone: ["bg-[#e8ef3d] text-black", "bg-[#17e3a8] text-black", "bg-[#21df78] text-black", "bg-[#28b6f6] text-black"][index],
-    verified: index === 2,
-    icon: <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><path d="M6 4h12v16H6z" /><path d="M9 8h6M9 12h6" /></svg>,
-  }));
+  const { data: trendingData, isLoading: trendingLoading } = useResources({ sort: "downloads", page_size: 4 });
+  const { data: featuredData, isLoading: featuredLoading } = useResources({ sort: "newest", page_size: 4 });
+  const trendingResources = trendingData?.results ?? [];
+  const featuredResources = featuredData?.results ?? [];
   const stats: Stat[] = [
     { value: direction === "rtl" ? "12.4 ألف" : "12.4k", label: home.stats.downloads },
     { value: "350+", label: home.stats.developers },
@@ -179,8 +162,26 @@ export default function HomePage() {
         </div>
       </section>
       <section className="mx-auto mt-16 w-full max-w-[1205px] px-5"><div className="grid min-h-[101px] overflow-hidden rounded-[21.8785px] bg-black text-white shadow-sm md:h-[101px] md:grid-cols-[240px_1fr_240px]" dir="ltr" style={{ background: "radial-gradient(circle at 4% 50%, rgba(67, 198, 118, 0.5) 10%, rgba(67, 198, 118, 0) 34%), radial-gradient(circle at 110% 50%, rgba(56, 185, 179, 0.95) 5%, rgba(67, 198, 118, 0) 34%), #000000" }}><div className="flex items-center justify-start gap-5 px-6 py-5" dir="ltr"><span className="text-3xl font-black leading-none text-white/40">...</span><Link href="/resources" className="rounded-full bg-white px-4 py-4 text-base font-black text-black">{home.announcements.action}</Link></div><p className="flex items-center justify-center px-6 py-5 text-center text-[18px] leading-[1.45]" dir={direction}>{home.announcements.text}</p><div className="flex items-center justify-end px-7 py-5 text-[38px] font-black leading-none" dir={direction}>{home.announcements.title}</div></div></section>
-      <section className="mx-auto mt-16 max-w-7xl px-5"><SectionHeading direction={direction}>{home.sections.trending}</SectionHeading><div className="grid gap-7 sm:grid-cols-2 lg:grid-cols-4">{resources.map((resource, index) => <ResourceTile key={`${resource.type}-${index}`} resource={resource} description={home.resourceCard.description} view={home.resourceCard.view} downloads={home.resourceCard.downloads} direction={direction} />)}</div></section>
-      <section className="mx-auto mt-16 max-w-7xl px-5"><SectionHeading direction={direction}>{home.sections.featured}</SectionHeading><div className="grid gap-7 sm:grid-cols-2 lg:grid-cols-4">{[...resources].reverse().map((resource, index) => <ResourceTile key={`${resource.type}-featured-${index}`} resource={resource} description={home.resourceCard.description} view={home.resourceCard.view} downloads={home.resourceCard.downloads} direction={direction} />)}</div></section>
+      {(trendingLoading || trendingResources.length > 0) && (
+        <section className="mx-auto mt-16 max-w-7xl px-5">
+          <SectionHeading direction={direction}>{home.sections.trending}</SectionHeading>
+          <div className="grid gap-7 sm:grid-cols-2 lg:grid-cols-4">
+            {trendingLoading
+              ? Array.from({ length: 4 }).map((_, index) => <div key={index} className="skeleton min-h-[305px] rounded-[13px]" />)
+              : trendingResources.map((resource) => <ResourceCard key={resource.id} resource={resource} />)}
+          </div>
+        </section>
+      )}
+      {(featuredLoading || featuredResources.length > 0) && (
+        <section className="mx-auto mt-16 max-w-7xl px-5">
+          <SectionHeading direction={direction}>{home.sections.featured}</SectionHeading>
+          <div className="grid gap-7 sm:grid-cols-2 lg:grid-cols-4">
+            {featuredLoading
+              ? Array.from({ length: 4 }).map((_, index) => <div key={index} className="skeleton min-h-[305px] rounded-[13px]" />)
+              : featuredResources.map((resource) => <ResourceCard key={resource.id} resource={resource} />)}
+          </div>
+        </section>
+      )}
       <section ref={statsSectionRef} className="mx-auto mt-20 max-w-7xl px-5"><h2 className="mb-8 text-4xl font-black text-black">{home.sections.stats}</h2><div className="grid gap-7 sm:grid-cols-2 lg:grid-cols-4">{stats.map((stat, index) => <div key={stat.label} className={`${statsVisible ? "stats-card-enter" : "stats-card-wait"} rounded-lg bg-[#fafafa] p-8 text-center`} style={{ animationDelay: (180 + index * 110) + "ms" }}><div className="text-4xl font-black text-black"><AnimatedCounter value={stat.value} active={statsVisible} delay={180 + index * 110} /></div><div className="mt-5 text-xl font-black text-black">{stat.label}</div></div>)}</div></section>
       <section ref={rocketSectionRef} className="mx-auto mt-16 max-w-7xl px-5 pb-20"><div className="grid items-stretch md:min-h-[340px] overflow-hidden rounded-2xl bg-[linear-gradient(122.15deg,#EBEFF0_30.7%,#D8E8F5_86.27%)] px-6 md:grid-cols-[330px_1fr] md:px-12" dir="ltr"><div className="flex h-[220px] items-end justify-center self-stretch overflow-hidden sm:h-[270px] md:h-full"><img src="/images/rocket.png" alt="" className="home-rocket h-full w-auto max-w-full object-contain object-bottom md:max-w-none" /></div><div className="flex flex-col items-start justify-center py-8 text-start md:py-10" dir={direction}><h2 className="text-4xl font-black leading-tight text-black">{home.publish.title}</h2><p className="mt-6 max-w-xl text-lg leading-9 text-[#7d8790]">{home.publish.subtitle}</p><Link href="/register" className="mt-8 rounded-full bg-black px-10 py-4 text-lg font-black text-white transition hover:bg-[#171717]">{home.publish.action}</Link></div></div></section>
     </div>


### PR DESCRIPTION
## Summary
- `src/app/page.tsx`'s Trending/Featured sections rendered a single hardcoded i18n object (`home.resourceCard`) across all 4 category slots in both sections - 8 cards that all showed the same fake title/description/downloads, only the category badge differed.
- Removes the fake `ResourceTile` + static `resources` array and wires both sections to `useResources()` (same hook already powering the `/resources` catalog), sorted by `downloads` for Trending and `newest` for Featured, rendered with the real `ResourceCard` component.

Closes #182

## Test plan
- [x] `pnpm test` passes
- [x] `tsc --noEmit` passes
- [ ] After merge/deploy, verify ratq.itqan.dev homepage shows distinct real resources in both sections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The homepage now displays trending and featured resources from live API data.
  * Added loading skeletons while resource content is retrieved.
  * Resource cards now use the shared presentation and support API-provided content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->