### PR TITLE
fix: add home i18n key and replace hardcoded ternary #173

### DIFF
--- a/src/shared/ui/i18n/messages/ar.json
+++ b/src/shared/ui/i18n/messages/ar.json
@@ -3,7 +3,8 @@
     "nav": {
       "resources": "الموارد",
       "about": "حول",
-      "dashboard": "لوحة التحكم"
+      "dashboard": "لوحة التحكم",
+      "home": "الرئيسية"
     },
     "auth": {
       "login": "تسجيل الدخول",

--- a/src/shared/ui/i18n/messages/en.json
+++ b/src/shared/ui/i18n/messages/en.json
@@ -3,7 +3,8 @@
     "nav": {
       "resources": "Resources",
       "about": "About",
-      "dashboard": "Dashboard"
+      "dashboard": "Dashboard",
+      "home": "Home"
     },
     "auth": {
       "login": "Log in",

--- a/src/shared/ui/layout/Header.tsx
+++ b/src/shared/ui/layout/Header.tsx
@@ -126,7 +126,7 @@ export function Header() {
               dir={direction}
             >
               <Link href="/" className={navLinkClass("/")} aria-current={isActive("/") ? "page" : undefined}>
-                {locale === "ar" ? "الرئيسية" : "Home"}
+                {t.header.nav.home}
               </Link>
               <Link href="/resources" className={navLinkClass("/resources")} aria-current={isActive("/resources") ? "page" : undefined}>
                 {t.header.nav.resources}
@@ -194,7 +194,7 @@ export function Header() {
             >
               <div className="grid gap-4 text-base text-black">
                 <Link href="/" className={mobileNavLinkClass("/")} aria-current={isActive("/") ? "page" : undefined} onClick={() => setMenuOpen(false)}>
-                  {locale === "ar" ? "الرئيسية" : "Home"}
+                  {t.header.nav.home}
                 </Link>
                 <Link href="/resources" className={mobileNavLinkClass("/resources")} aria-current={isActive("/resources") ? "page" : undefined} onClick={() => setMenuOpen(false)}>
                   {t.header.nav.resources}


### PR DESCRIPTION
"Closes #173"
"Added home i18n key to en.json and ar.json"
"Replaced hardcoded ternary in Header.tsx with t.header.nav.home"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Added translated “Home” navigation labels in English and Arabic.
  * Updated desktop and mobile navigation to display the appropriate localized label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->