### PR TITLE
Fix developer mock comments

### DIFF
--- a/src/app/developer/comments/page.tsx
+++ b/src/app/developer/comments/page.tsx
@@ -1,41 +1,12 @@
 'use client';
 
 import { useState } from 'react';
+import { useDeveloperComments } from '@/hooks/useDeveloperComments';
 import { CommentRow } from '@/modules/developer/components/CommentRow';
-import type { Comment } from '@/types/resource';
-
-const mockCommentsWithResources = [
-  {
-    comment: {
-      id: 501,
-      author_name: 'محمد أحمد',
-      content: 'مكتبة ممتازة! التحليل الصرفي كان مفيداً جداً لمشروع البحث الخاص بي.',
-      created_at: '2026-02-10T14:30:00Z',
-    },
-    resource_name: 'Quranic Text Toolkit (QTT)',
-  },
-  {
-    comment: {
-      id: 502,
-      author_name: 'محمد أحمد',
-      content: 'هل يمكن إضافة دعم لخط الإنديك؟ هذا سيكون مفيداً جداً للمشاريع التي تستهدف جنوب آسيا.',
-      created_at: '2026-03-05T09:15:00Z',
-    },
-    resource_name: 'Quranic Text Toolkit (QTT)',
-  },
-  {
-    comment: {
-      id: 503,
-      author_name: 'محمد أحمد',
-      content: 'SDK جيد جداً. المزامنة مع التلاوات ميزة رائعة.',
-      created_at: '2026-01-20T16:45:00Z',
-    },
-    resource_name: 'Quranic Audio SDK',
-  },
-];
 
 export default function DeveloperCommentsPage() {
   const [activeTab, setActiveTab] = useState<'my-comments' | 'discussions'>('my-comments');
+  const { data: comments, isLoading } = useDeveloperComments();
 
   return (
     <div>
@@ -69,11 +40,26 @@ export default function DeveloperCommentsPage() {
 
       {/* Tab content */}
       {activeTab === 'my-comments' && (
-        <div className="space-y-3">
-          {mockCommentsWithResources.map(({ comment, resource_name }) => (
-            <CommentRow key={comment.id} comment={comment} resourceName={resource_name} />
-          ))}
-        </div>
+        isLoading ? (
+          <div className="space-y-3">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="card p-4 animate-pulse">
+                <div className="skeleton h-4 w-1/3 rounded mb-2" />
+                <div className="skeleton h-3 w-2/3 rounded" />
+              </div>
+            ))}
+          </div>
+        ) : (comments ?? []).length === 0 ? (
+          <div className="card p-8 text-center">
+            <p className="text-[var(--text-muted)]">لا توجد تعليقات بعد</p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {(comments ?? []).map(({ comment, resource_name }) => (
+              <CommentRow key={comment.id} comment={comment} resourceName={resource_name} />
+            ))}
+          </div>
+        )
       )}
 
       {activeTab === 'discussions' && (

--- a/src/hooks/useDeveloperComments.ts
+++ b/src/hooks/useDeveloperComments.ts
@@ -1,0 +1,12 @@
+'use client';
+
+import useSWR from 'swr';
+import { listMyComments } from '@/modules/resources/application/use-cases/list-my-comments';
+import type { CommentWithResource } from '@/types/resource';
+
+export function useDeveloperComments() {
+  return useSWR<CommentWithResource[], Error>(
+    ['developer', 'comments'],
+    () => listMyComments()
+  );
+}

--- a/src/modules/resources/application/use-cases/list-my-comments.ts
+++ b/src/modules/resources/application/use-cases/list-my-comments.ts
@@ -1,0 +1,3 @@
+import { fetchMyComments } from '../../infrastructure/comments-api';
+
+export const listMyComments = fetchMyComments;

--- a/src/modules/resources/infrastructure/comments-api.ts
+++ b/src/modules/resources/infrastructure/comments-api.ts
@@ -1,5 +1,5 @@
-import type { Comment } from '@/types/resource';
-import { getAccessToken } from '@/shared/infrastructure/token-storage';
+import type { Comment, CommentWithResource } from '@/types/resource';
+import { getAccessToken, getCurrentUserId } from '@/shared/infrastructure/token-storage';
 import { payloadErrorMessage } from '@/shared/infrastructure/payload-error';
 import { PAYLOAD_API_BASE } from '@/shared/infrastructure/payload-config';
 
@@ -13,10 +13,16 @@ interface PayloadCommentDoc {
   content: string;
   createdAt: string;
   author_name: string;
+  resource?: number | { id: number; name: string };
 }
 
 function toComment(doc: PayloadCommentDoc): Comment {
   return { id: doc.id, author_name: doc.author_name, content: doc.content, created_at: doc.createdAt };
+}
+
+function toCommentWithResource(doc: PayloadCommentDoc): CommentWithResource {
+  const resourceName = typeof doc.resource === 'object' ? doc.resource.name : 'Unknown';
+  return { comment: toComment(doc), resource_name: resourceName };
 }
 
 export async function fetchComments(resourceId: number): Promise<Comment[]> {
@@ -42,4 +48,17 @@ export async function postComment(resourceId: number, content: string): Promise<
   if (!res.ok) throw new Error(await payloadErrorMessage(res, 'Failed to post comment'));
   const result: { doc: PayloadCommentDoc } = await res.json();
   return toComment(result.doc);
+}
+
+export async function fetchMyComments(): Promise<CommentWithResource[]> {
+  const userId = getCurrentUserId();
+  if (!userId) return [];
+
+  const res = await fetch(
+    `${PAYLOAD_API_BASE}/comments?where[author][equals]=${userId}&sort=-createdAt&depth=1&limit=100`,
+    { headers: { Authorization: `JWT ${getAccessToken()}` } }
+  );
+  if (!res.ok) throw new Error('Failed to fetch comments');
+  const data: { docs: PayloadCommentDoc[] } = await res.json();
+  return data.docs.map(toCommentWithResource);
 }

--- a/src/types/resource.ts
+++ b/src/types/resource.ts
@@ -79,6 +79,11 @@ export interface Comment {
   created_at: string;
 }
 
+export interface CommentWithResource {
+  comment: Comment;
+  resource_name: string;
+}
+
 // ─── Access Request Types ─────────────────────────────────────────────────
 
 export type RequestStatus = 'pending' | 'approved' | 'denied';


### PR DESCRIPTION
fixes: #169 

**What this fixes**
Mock comments was always rendered instead of showing the actual user comments 

**Fix**
Added an interface that returns the comment with the resource name and added two functions in comments-api.ts: 
first one return the comments with the resource name 
second one fetches the comments and return them with resource name 

A hook is created to fetch comments and used in the comment page instead of the mock comments 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Developer comments now load from live account data instead of sample content.
  * Comments display their associated resource names.
  * Added loading indicators while comments are retrieved.
  * Added an empty state when no comments are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->