### PR TITLE
Fix: prevent navbar from hiding developer sidebar and content

### DIFF
--- a/src/__tests__/DeveloperLayout.test.tsx
+++ b/src/__tests__/DeveloperLayout.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import DeveloperLayout from '@/app/developer/layout';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/developer',
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, className, onClick }: any) => (
+    <span className={className} onClick={onClick}>
+      {children}
+    </span>
+  ),
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: { id: '1', display_name: 'Test User', role: 'developer' },
+    loading: false,
+    logout: vi.fn(),
+  }),
+}));
+
+describe('DeveloperLayout', () => {
+  it('offsets the sticky top bar below the fixed root header (regression for #199)', () => {
+    render(
+      <DeveloperLayout>
+        <div>content</div>
+      </DeveloperLayout>
+    );
+
+    const topBar = screen.getByText('Test User').closest('div.sticky');
+    expect(topBar).toHaveClass('top-32');
+    // Guard against regressing back to top-0, which is hidden behind the
+    // root Header (sticky top-0 z-50) once the page is scrolled.
+    expect(topBar).not.toHaveClass('top-0');
+  });
+});

--- a/src/app/developer/layout.tsx
+++ b/src/app/developer/layout.tsx
@@ -50,7 +50,7 @@ export default function DeveloperLayout({
 
       <div className="flex-grow pt-32">
         {/* Top bar */}
-        <div className="bg-[var(--bg-card)] border-b border-[var(--border-color)] px-6 py-4 flex items-center justify-between sticky top-0 z-20">
+        <div className="bg-[var(--bg-card)] border-b border-[var(--border-color)] px-6 py-4 flex items-center justify-between sticky top-32 z-20">
           <div className="flex items-center gap-3">
             {/* Mobile hamburger toggle */}
             <button

--- a/src/app/developer/layout.tsx
+++ b/src/app/developer/layout.tsx
@@ -48,7 +48,7 @@ export default function DeveloperLayout({
         />
       )}
 
-      <div className="flex-grow">
+      <div className="flex-grow pt-32">
         {/* Top bar */}
         <div className="bg-[var(--bg-card)] border-b border-[var(--border-color)] px-6 py-4 flex items-center justify-between sticky top-0 z-20">
           <div className="flex items-center gap-3">

--- a/src/modules/developer/components/DeveloperSidebar.tsx
+++ b/src/modules/developer/components/DeveloperSidebar.tsx
@@ -25,7 +25,7 @@ export function DeveloperSidebar({
 
   return (
     <aside
-      className={`fixed top-0 right-0 h-full w-64 bg-[var(--bg-card)] border-l border-[var(--border-color)] z-40 overflow-y-auto transition-transform duration-300 lg:sticky lg:top-0 lg:h-screen lg:shrink-0
+      className={`fixed top-0 right-0 h-full w-64 bg-[var(--bg-card)] border-l border-[var(--border-color)] z-40 overflow-y-auto transition-transform duration-300 lg:sticky lg:top-32 lg:h-[calc(100vh-8rem)] lg:shrink-0
         ${mobileOpen ? 'translate-x-0' : 'translate-x-full lg:translate-x-0'}
       `}
     >


### PR DESCRIPTION
## After:
<img width="1824" height="648" alt="Screenshot From 2026-08-14 03-59-36" src="https://github.com/user-attachments/assets/2ecd8b70-a8f2-4f6d-8b80-50d2c693460f" />

## Before:
<img width="1820" height="680" alt="Screenshot From 2026-08-14 04-06-51" src="https://github.com/user-attachments/assets/89f66665-4559-4110-9eb0-2ce408ba1233" />

Fixes #199

## What's wrong
The root layout's Header renders with a fixed visual offset (~8rem), but the developer view's sidebar and content wrapper had no matching top offset, so the header overlapped part of the sidebar and page content.

## Fix
- `DeveloperSidebar.tsx`: changed sticky offset from `lg:top-0` to `lg:top-32` (matching the shared `Sidebar.tsx` pattern) and adjusted height accordingly
- `developer/layout.tsx`: added `pt-32` to the content wrapper (matching the pattern already used in `dashboard/page.tsx`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved spacing at the top of developer pages.
  - Updated the desktop sidebar to remain visible while scrolling within the page layout.
  - Preserved existing mobile sidebar behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->