### PR TITLE
Feat: add /contributors Hall of Fame page

### DIFF
--- a/src/app/contributors/contributors-data.ts
+++ b/src/app/contributors/contributors-data.ts
@@ -1,0 +1,45 @@
+export interface Contributor {
+  name: string;
+  githubUsername: string;
+  githubUrl: string;
+  avatarUrl: string;
+  contribution: string;
+  issueUrl: string;
+  prUrl: string;
+}
+
+// Curated by hand alongside the Flarum Hall of Fame post and GitHub
+// Discussion leaderboard (see issue #197). Update this list manually when a
+// new community PR is merged and added to those two sources.
+export const contributors: Contributor[] = [
+  {
+    name: 'Omarr-kh',
+    githubUsername: 'Omarr-kh',
+    githubUrl: 'https://github.com/Omarr-kh',
+    avatarUrl: 'https://github.com/Omarr-kh.png',
+    contribution:
+      'Removed a fake, hardcoded GitHub repo browser from the resource detail page.',
+    issueUrl: 'https://github.com/Itqan-community/RATQ/issues/180',
+    prUrl: 'https://github.com/Itqan-community/RATQ/pull/188',
+  },
+  {
+    name: 'sanataff',
+    githubUsername: 'sanataff',
+    githubUrl: 'https://github.com/sanataff',
+    avatarUrl: 'https://github.com/sanataff.png',
+    contribution:
+      'Deleted dead i18n source files (en.ts / ar.ts) that were never imported, and fixed the stale docs pointing to them.',
+    issueUrl: 'https://github.com/Itqan-community/RATQ/issues/172',
+    prUrl: 'https://github.com/Itqan-community/RATQ/pull/191',
+  },
+  {
+    name: 'abatn',
+    githubUsername: 'abatn',
+    githubUrl: 'https://github.com/abatn',
+    avatarUrl: 'https://github.com/abatn.png',
+    contribution:
+      "Fixed a missing 'Home' nav i18n key that was hardcoded as a ternary instead of going through the translation object.",
+    issueUrl: 'https://github.com/Itqan-community/RATQ/issues/173',
+    prUrl: 'https://github.com/Itqan-community/RATQ/pull/190',
+  },
+];

--- a/src/app/contributors/page.tsx
+++ b/src/app/contributors/page.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useLanguage } from '@/shared/ui/i18n';
+import { contributors } from './contributors-data';
+
+export default function ContributorsPage() {
+  const { t, direction } = useLanguage();
+
+  return (
+    <main
+      className="page-enter relative isolate min-h-screen bg-[linear-gradient(145deg,#EBEFF0_0%,#F7F9FA_48%,#D8E8F5_100%)] bg-fixed pb-20 pt-32 text-black"
+      dir={direction}
+    >
+      <section className="relative z-10 mx-auto max-w-[1480px] px-3 sm:px-4">
+        <div className="px-3 pb-10 pt-16 sm:px-10 sm:pt-24 lg:px-16 lg:pb-12 lg:pt-28">
+          <div className="max-w-4xl">
+            <h1 className="text-4xl font-black leading-[1.2] text-black sm:text-5xl">
+              {t.contributors.pageTitle}
+            </h1>
+            <p className="mt-6 max-w-3xl text-base leading-8 text-[#59636d] sm:text-lg sm:leading-9">
+              {t.contributors.subtitle}
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="relative z-10 mx-auto mt-10 max-w-[980px] px-5">
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {contributors.map((contributor) => (
+            <article
+              key={contributor.githubUsername}
+              className="flex flex-col gap-4 rounded-lg border border-[#ededed] bg-white p-6 shadow-[0_8px_24px_rgba(15,23,42,0.035)]"
+            >
+              <div className="flex items-center gap-3">
+                <a
+                  href={contributor.githubUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="shrink-0"
+                >
+                  {/* eslint-disable-next-line @next/next/no-img-element -- external GitHub avatar, not part of the local image pipeline */}
+                  <img
+                    src={contributor.avatarUrl}
+                    alt={contributor.name}
+                    width={56}
+                    height={56}
+                    className="h-14 w-14 rounded-full object-cover"
+                  />
+                </a>
+                <a
+                  href={contributor.githubUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-black text-black hover:underline"
+                >
+                  {contributor.name}
+                </a>
+              </div>
+
+              <p className="text-sm leading-7 text-[#59636d]" dir="ltr">
+                {contributor.contribution}
+              </p>
+
+              <div className="mt-auto flex flex-wrap gap-4 text-xs font-black">
+                <a
+                  href={contributor.issueUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-[#171717] hover:underline"
+                >
+                  {t.contributors.viewIssue}
+                </a>
+                <a
+                  href={contributor.prUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-[#171717] hover:underline"
+                >
+                  {t.contributors.viewPr}
+                </a>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/shared/ui/i18n/messages/ar.json
+++ b/src/shared/ui/i18n/messages/ar.json
@@ -4,7 +4,8 @@
       "resources": "الموارد",
       "about": "حول",
       "dashboard": "لوحة التحكم",
-      "home": "الرئيسية"
+      "home": "الرئيسية",
+      "contributors": "المساهمون"
     },
     "auth": {
       "login": "تسجيل الدخول",
@@ -457,5 +458,11 @@
     "publisherDescription": "أشارك الموارد وأديرها",
     "createAccount": "إنشاء الحساب",
     "creatingAccount": "جاري إنشاء الحساب..."
+  },
+  "contributors": {
+    "pageTitle": "المساهمون",
+    "subtitle": "تُبنى RATQ بمساهمة المجتمع. هؤلاء المساهمون أصلحوا أخطاء وأغلقوا مشكلات وقدّموا تحسينات للمنصة.",
+    "viewIssue": "المشكلة",
+    "viewPr": "طلب الدمج"
   }
 }

--- a/src/shared/ui/i18n/messages/en.json
+++ b/src/shared/ui/i18n/messages/en.json
@@ -4,7 +4,8 @@
       "resources": "Resources",
       "about": "About",
       "dashboard": "Dashboard",
-      "home": "Home"
+      "home": "Home",
+      "contributors": "Contributors"
     },
     "auth": {
       "login": "Log in",
@@ -457,5 +458,11 @@
     "publisherDescription": "Share and manage resources",
     "createAccount": "Create account",
     "creatingAccount": "Creating account..."
+  },
+  "contributors": {
+    "pageTitle": "Contributors",
+    "subtitle": "RATQ is built with the community. These contributors have fixed bugs, closed issues, and shipped improvements to the platform.",
+    "viewIssue": "Issue",
+    "viewPr": "Pull request"
   }
 }

--- a/src/shared/ui/layout/Header.tsx
+++ b/src/shared/ui/layout/Header.tsx
@@ -134,6 +134,9 @@ export function Header() {
               <Link href="/about" className={navLinkClass("/about")} aria-current={isActive("/about") ? "page" : undefined}>
                 {t.header.nav.about}
               </Link>
+              <Link href="/contributors" className={navLinkClass("/contributors")} aria-current={isActive("/contributors") ? "page" : undefined}>
+                {t.header.nav.contributors}
+              </Link>
               <Link href="/dashboard" className={navLinkClass("/dashboard")} aria-current={isActive("/dashboard") ? "page" : undefined}>
                 {t.header.nav.dashboard}
               </Link>
@@ -201,6 +204,9 @@ export function Header() {
                 </Link>
                 <Link href="/about" className={mobileNavLinkClass("/about")} aria-current={isActive("/about") ? "page" : undefined} onClick={() => setMenuOpen(false)}>
                   {t.header.nav.about}
+                </Link>
+                <Link href="/contributors" className={mobileNavLinkClass("/contributors")} aria-current={isActive("/contributors") ? "page" : undefined} onClick={() => setMenuOpen(false)}>
+                  {t.header.nav.contributors}
                 </Link>
                 <Link href="/dashboard" className={mobileNavLinkClass("/dashboard")} aria-current={isActive("/dashboard") ? "page" : undefined} onClick={() => setMenuOpen(false)}>
                   {t.header.nav.dashboard}


### PR DESCRIPTION
Adds a static Contributors page mirroring the existing Flarum post and GitHub Discussion leaderboard, per issue #197.

- src/app/contributors/page.tsx + contributors-data.ts (static, curated list, no live GitHub API call)
- Contributors nav link in Header.tsx (desktop + mobile)
- New i18n keys in en.json/ar.json (header.nav.contributors + a contributors section)

Seeded with the 3 contributors named in the issue. Contribution descriptions here are drafted from the linked issue/PR titles since I don't have access to the Flarum post itself happy to swap in the exact wording from there if someone can share it.

Closes #197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Contributors page showcasing contributor profiles, avatars, contributions, GitHub profiles, related issues, and pull requests.
  * Added Contributors links to desktop and mobile navigation menus.
  * Added English and Arabic translations for the page and navigation label.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->