### PR TITLE
Fix authenticated hydration mismatch

### DIFF
--- a/src/__tests__/useAuth.test.tsx
+++ b/src/__tests__/useAuth.test.tsx
@@ -1,0 +1,120 @@
+import { act } from 'react';
+import { hydrateRoot } from 'react-dom/client';
+import { renderToString } from 'react-dom/server';
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AuthProvider, useAuth } from '@/hooks/useAuth';
+import type { User } from '@/types/resource';
+
+const storedUser: User = {
+  id: 42,
+  email: 'developer@example.com',
+  display_name: 'Test Developer',
+  role: 'developer',
+  created_at: '2026-08-14T00:00:00.000Z',
+};
+
+function jwtWithExp(exp: number): string {
+  const header = btoa(JSON.stringify({ alg: 'HS256' }));
+  const payload = btoa(JSON.stringify({ exp }));
+  return `${header}.${payload}.signature`;
+}
+
+function storeSession(exp: number) {
+  const token = jwtWithExp(exp);
+  localStorage.setItem('ratq_access_token', token);
+  localStorage.setItem('ratq_refresh_token', token);
+  localStorage.setItem('ratq_user', JSON.stringify(storedUser));
+}
+
+function AuthStateProbe() {
+  const { user, loading } = useAuth();
+
+  return (
+    <p data-testid="auth-state">
+      {loading ? 'loading' : user?.email ?? 'anonymous'}
+    </p>
+  );
+}
+
+describe('AuthProvider hydration', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('hydrates without a mismatch and restores a stored session', async () => {
+    const serverHtml = renderToString(
+      <AuthProvider>
+        <AuthStateProbe />
+      </AuthProvider>
+    );
+    expect(serverHtml).toContain('loading');
+
+    const container = document.createElement('div');
+    container.innerHTML = serverHtml;
+    document.body.appendChild(container);
+    storeSession(Math.floor(Date.now() / 1000) + 3600);
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const root = hydrateRoot(
+      container,
+      <AuthProvider>
+        <AuthStateProbe />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(container).toHaveTextContent(storedUser.email);
+    });
+
+    const errors = consoleError.mock.calls.flat().map(String).join(' ');
+    expect(errors).not.toMatch(/hydration|did not match|server rendered html/i);
+
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it('restores a valid stored user after mounting', async () => {
+    storeSession(Math.floor(Date.now() / 1000) + 3600);
+
+    render(
+      <AuthProvider>
+        <AuthStateProbe />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auth-state')).toHaveTextContent(storedUser.email);
+    });
+  });
+
+  it('resolves to anonymous when no session is stored', async () => {
+    render(
+      <AuthProvider>
+        <AuthStateProbe />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auth-state')).toHaveTextContent('anonymous');
+    });
+  });
+
+  it('clears an expired stored session', async () => {
+    storeSession(Math.floor(Date.now() / 1000) - 60);
+
+    render(
+      <AuthProvider>
+        <AuthStateProbe />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auth-state')).toHaveTextContent('anonymous');
+    });
+    expect(localStorage.getItem('ratq_access_token')).toBeNull();
+    expect(localStorage.getItem('ratq_refresh_token')).toBeNull();
+    expect(localStorage.getItem('ratq_user')).toBeNull();
+  });
+});

--- a/src/__tests__/useAuth.test.tsx
+++ b/src/__tests__/useAuth.test.tsx
@@ -57,11 +57,13 @@ describe('AuthProvider hydration', () => {
     storeSession(Math.floor(Date.now() / 1000) + 3600);
 
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const root = hydrateRoot(
-      container,
-      <AuthProvider>
-        <AuthStateProbe />
-      </AuthProvider>
+    const root = await act(() =>
+      hydrateRoot(
+        container,
+        <AuthProvider>
+          <AuthStateProbe />
+        </AuthProvider>
+      )
     );
 
     await waitFor(() => {

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -4,6 +4,7 @@ import {
   createContext,
   useContext,
   useState,
+  useEffect,
   useCallback,
   type ReactNode,
 } from 'react';
@@ -50,9 +51,16 @@ type AuthContextType = {
 const AuthContext = createContext<AuthContextType | null>(null);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
-  const [user, setUser] = useState<User | null>(getUserFromStorage);
-  const [loading, setLoading] = useState(false);
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    /* eslint-disable react-hooks/set-state-in-effect -- Restore browser-only auth state after hydration so the server and first client render match. */
+    setUser(getUserFromStorage());
+    setLoading(false);
+    /* eslint-enable react-hooks/set-state-in-effect */
+  }, []);
 
   const login = useCallback(async (email: string, password: string) => {
     setLoading(true);


### PR DESCRIPTION
## Summary

- make the server render and initial client render use the same authentication state
- restore a valid stored session after hydration while keeping protected routes gated by loading state
- add regression coverage for authenticated hydration, anonymous sessions, and expired sessions

## Root cause

`AuthProvider` read `localStorage` from its `useState` initializer. The server rendered an anonymous state, while an authenticated browser could render a stored user during hydration, causing React error #418.

## Verification

- `npm run test:run` — 105 tests passed
- `npx tsc --noEmit`
- `npx eslint src/hooks/useAuth.tsx src/__tests__/useAuth.test.tsx`
- `npm run build`
- manually refreshed `/developer` several times while authenticated; the session persisted without a hydration error

Closes #154


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication state restoration during page loading.
  * Prevented server-rendering and client-side hydration mismatches.
  * Expired stored sessions are now cleaned up automatically.
  * Users with valid saved sessions are restored after hydration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->