### PR TITLE
Add usefahmed07 to the Contributors page

### DIFF
--- a/src/app/contributors/contributors-data.ts
+++ b/src/app/contributors/contributors-data.ts
@@ -42,4 +42,14 @@ export const contributors: Contributor[] = [
     issueUrl: 'https://github.com/Itqan-community/RATQ/issues/173',
     prUrl: 'https://github.com/Itqan-community/RATQ/pull/190',
   },
+  {
+    name: 'usefahmed07',
+    githubUsername: 'usefahmed07',
+    githubUrl: 'https://github.com/usefahmed07',
+    avatarUrl: 'https://github.com/usefahmed07.png',
+    contribution:
+      'Built this Contributors page, and fixed the developer view navbar overlapping the sidebar.',
+    issueUrl: 'https://github.com/Itqan-community/RATQ/issues/197',
+    prUrl: 'https://github.com/Itqan-community/RATQ/pull/201',
+  },
 ];


### PR DESCRIPTION
He built the Contributors page itself (#201, closing #197) and fixed the developer sidebar overlap (#200, closing #199), but the static data file only had the 3 contributors already documented in #197 at the time he wrote it. Adding his own entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contributor profile and contribution details for `usefahmed07` to the curated contributors list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->