### PR TITLE
fix: strip stray UTF-8 BOM from resources source files

### DIFF
--- a/src/app/resources/page.tsx
+++ b/src/app/resources/page.tsx
@@ -1,4 +1,4 @@
-﻿import { Suspense } from 'react';
+import { Suspense } from 'react';
 import { CatalogContent } from './CatalogContent';
 
 export default function CatalogPage() {

--- a/src/modules/resources/components/GithubStatsCard.tsx
+++ b/src/modules/resources/components/GithubStatsCard.tsx
@@ -1,4 +1,4 @@
-﻿'use client';
+'use client';
 
 import { formatDate } from '@/shared/utils/utils';
 import type { GithubStats } from '@/types/resource';

--- a/src/modules/resources/components/ReportButton.tsx
+++ b/src/modules/resources/components/ReportButton.tsx
@@ -1,4 +1,4 @@
-﻿'use client';
+'use client';
 
 import { useState } from 'react';
 import Link from 'next/link';


### PR DESCRIPTION
## Summary

Removes the leading UTF-8 BOM byte from 3 source files that had it. Purely
a byte-level encoding fix — no behavior change.

## Files fixed

- `src/app/resources/page.tsx`
- `src/modules/resources/components/GithubStatsCard.tsx`
- `src/modules/resources/components/ReportButton.tsx`

## Note

The issue originally listed 5 files. 2 of them (`ResourceGrid.tsx` and
`ResourceFilters.tsx`) no longer exist in the current `src/` tree after
the DDD restructure — confirmed via search before starting, per the
issue's note. Only the 3 files above still had a BOM.

## Verification

- Detected BOM via raw byte read (`EF BB BF`) before the fix, confirmed
  absent after
- `npm run build` — passes, all routes generated successfully
- `npm run lint` — pre-existing errors/warnings unrelated to the changed
  files remain (none in the 3 files touched here); confirmed via
  `git stash` that they exist on `main` independently of this change
- `npm test` — no change in test behavior before/after this fix

Closes #171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up file encoding markers in resource pages and components.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->