### PR TITLE
docs: add CODE_OF_CONDUCT.md and governance doc (#167)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,45 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Community leaders have the right and responsibility to remove, reject, or edit comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for enforcement decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,3 +68,11 @@ You're welcome to use AI coding tools, but the PR is still your responsibility: 
 ## Questions
 
 Open a GitHub Issue with the `question` label, or ask in the linked community channels once available. See the [RATQ Roadmap](https://app.notion.com/p/3a97056925c8808991f9c2073cc28f25) for what's currently planned.
+
+## Governance & Decision Making
+
+This project follows a lightweight, community-first governance model:
+
+- **Maintainer Roles:** Project maintainers (`@abubakr-itqan` and community leads) have direct merge rights, review pull requests, and manage issue assignments.
+- **Decision Making:** Technical and design choices are discussed transparently within GitHub Issues and Pull Requests. Consensus is driven through open discussion, with final review authority held by project maintainers.
+- **Code of Conduct:** All contributors and maintainers are expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Open [http://localhost:3000](http://localhost:3000).
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup details, coding standards, and the PR process. All contributions target the `main` branch.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup details, coding standards, and the PR process. Please also read our [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) for community standards. All contributions target the `main` branch.
 
 ## License
 


### PR DESCRIPTION
Fixes #167

- Added CODE_OF_CONDUCT.md using Contributor Covenant v2.1 standard.
- Added lightweight Governance section to CONTRIBUTING.md.
- Updated README.md to reference community guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Code of Conduct outlining community standards, reporting procedures, and enforcement responsibilities.
  * Added governance and decision-making guidance for maintainers and contributors.
  * Updated contribution guidelines to reference the Code of Conduct.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->