### PR TITLE
Feat: wire pagination controls into /resources catalog (#146)

### DIFF
--- a/src/__tests__/CatalogContent.test.tsx
+++ b/src/__tests__/CatalogContent.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { CatalogContent } from '@/app/resources/CatalogContent';
+import { LanguageProvider } from '@/shared/ui/i18n/LanguageContext';
+
+const mockUseResources = vi.fn();
+let mockSearchParams = new URLSearchParams();
+const mockPush = vi.fn();
+
+vi.mock('@/hooks/useResources', () => ({
+  useResources: (...args: unknown[]) => mockUseResources(...args),
+}));
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => mockSearchParams,
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...rest }: any) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+function renderWithProvider(ui: React.ReactElement) {
+  localStorage.setItem('ratq_locale', 'en');
+  const result = render(<LanguageProvider>{ui}</LanguageProvider>);
+  act(() => {});
+  return result;
+}
+
+function makeResource(id: number) {
+  return {
+    id,
+    name: `Resource ${id}`,
+    slug: `resource-${id}`,
+    source: 'ratq',
+    source_url: null,
+    type: 'library',
+    description: 'desc',
+    short_description: 'short desc',
+    documentation_url: null,
+    github_url: null,
+    license: 'MIT',
+    itqan_badge: false,
+    status: 'published',
+    created_at: '2026-01-01',
+    updated_at: '2026-01-01',
+    version: null,
+    github_stats: null,
+    total_downloads: 0,
+    downloads: 0,
+  };
+}
+
+describe('CatalogContent pagination', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
+  });
+
+  it('requests page 1 by default when no page param is present', () => {
+    mockUseResources.mockReturnValue({ data: { count: 0, next: null, previous: null, results: [] }, error: undefined, isLoading: false });
+    renderWithProvider(<CatalogContent />);
+    expect(mockUseResources).toHaveBeenCalledWith({ page: 1, page_size: 12 });
+  });
+
+  it('reads the page number from the page query param', () => {
+    mockSearchParams = new URLSearchParams('page=3');
+    mockUseResources.mockReturnValue({ data: { count: 30, next: null, previous: null, results: [makeResource(1)] }, error: undefined, isLoading: false });
+    renderWithProvider(<CatalogContent />);
+    expect(mockUseResources).toHaveBeenCalledWith({ page: 3, page_size: 12 });
+  });
+
+  it('falls back to page 1 for an invalid page param', () => {
+    mockSearchParams = new URLSearchParams('page=not-a-number');
+    mockUseResources.mockReturnValue({ data: { count: 0, next: null, previous: null, results: [] }, error: undefined, isLoading: false });
+    renderWithProvider(<CatalogContent />);
+    expect(mockUseResources).toHaveBeenCalledWith({ page: 1, page_size: 12 });
+  });
+
+  it('renders pagination controls when there is more than one page of results', () => {
+    mockUseResources.mockReturnValue({
+      data: { count: 30, next: '/api/resources?page=2', previous: null, results: [makeResource(1)] },
+      error: undefined,
+      isLoading: false,
+    });
+    renderWithProvider(<CatalogContent />);
+    expect(screen.getByRole('navigation', { name: /pagination/i })).toBeInTheDocument();
+  });
+
+  it('does not render pagination controls when results fit on one page', () => {
+    mockUseResources.mockReturnValue({
+      data: { count: 1, next: null, previous: null, results: [makeResource(1)] },
+      error: undefined,
+      isLoading: false,
+    });
+    renderWithProvider(<CatalogContent />);
+    expect(screen.queryByRole('navigation', { name: /pagination/i })).not.toBeInTheDocument();
+  });
+
+  it('does not render pagination controls in the empty state', () => {
+    mockUseResources.mockReturnValue({ data: { count: 0, next: null, previous: null, results: [] }, error: undefined, isLoading: false });
+    renderWithProvider(<CatalogContent />);
+    expect(screen.queryByRole('navigation', { name: /pagination/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/Pagination.test.tsx
+++ b/src/__tests__/Pagination.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { Pagination } from '@/shared/ui/Pagination';
+import { LanguageProvider } from '@/shared/ui/i18n/LanguageContext';
+
+let mockSearchParams = new URLSearchParams();
+const mockPush = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => mockSearchParams,
+  useRouter: () => ({ push: mockPush }),
+}));
+
+function renderWithProvider(ui: React.ReactElement) {
+  localStorage.setItem('ratq_locale', 'en');
+  const result = render(<LanguageProvider>{ui}</LanguageProvider>);
+  act(() => {});
+  return result;
+}
+
+describe('Pagination', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
+  });
+
+  it('renders nothing when everything fits on one page', () => {
+    const { container } = renderWithProvider(<Pagination count={5} pageSize={12} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('treats an invalid page param as page 1 instead of NaN', () => {
+    mockSearchParams = new URLSearchParams('page=not-a-number');
+    renderWithProvider(<Pagination count={30} pageSize={12} />);
+
+    expect(screen.getByRole('button', { name: '1' })).toHaveClass('bg-[var(--accent-primary)]');
+    expect(screen.getByRole('button', { name: /prev/i })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    expect(mockPush).toHaveBeenCalledWith('/resources?page=2');
+  });
+
+  it('treats a missing page param as page 1', () => {
+    renderWithProvider(<Pagination count={30} pageSize={12} />);
+    expect(screen.getByRole('button', { name: /prev/i })).toBeDisabled();
+  });
+
+  it('navigates to the correct page on Next/Prev clicks', () => {
+    mockSearchParams = new URLSearchParams('page=2');
+    renderWithProvider(<Pagination count={30} pageSize={12} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    expect(mockPush).toHaveBeenCalledWith('/resources?page=3');
+
+    fireEvent.click(screen.getByRole('button', { name: /prev/i }));
+    expect(mockPush).toHaveBeenCalledWith('/resources?page=1');
+  });
+});

--- a/src/app/resources/CatalogContent.tsx
+++ b/src/app/resources/CatalogContent.tsx
@@ -1,13 +1,19 @@
 'use client';
 
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 import { useLanguage } from '@/shared/ui/i18n';
 import { ResourceCard } from '@/modules/resources/components/ResourceCard';
+import { Pagination } from '@/shared/ui/Pagination';
 import { useResources } from '@/hooks/useResources';
+
+const PAGE_SIZE = 12;
 
 export function CatalogContent() {
   const { locale, direction, t } = useLanguage();
-  const { data, error, isLoading } = useResources();
+  const searchParams = useSearchParams();
+  const page = Math.max(1, parseInt(searchParams.get('page') || '1', 10) || 1);
+  const { data, error, isLoading } = useResources({ page, page_size: PAGE_SIZE });
   const resources = data?.results ?? [];
 
   return (
@@ -41,11 +47,14 @@ export function CatalogContent() {
             <p className="mt-2 text-sm text-[#8b8b8b]">{t.catalog.noResources.subtitle}</p>
           </section>
         ) : (
-          <section className="mt-7 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
-            {resources.map((resource) => (
-              <ResourceCard key={resource.id} resource={resource} />
-            ))}
-          </section>
+          <>
+            <section className="mt-7 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+              {resources.map((resource) => (
+                <ResourceCard key={resource.id} resource={resource} />
+              ))}
+            </section>
+            <Pagination count={data?.count ?? 0} pageSize={PAGE_SIZE} />
+          </>
         )}
 
         <section className="mt-24 overflow-hidden rounded-[24px] bg-[linear-gradient(112deg,#edf1f1_15%,#dbeaf6_100%)] px-7 sm:px-12">

--- a/src/app/resources/CatalogContent.tsx
+++ b/src/app/resources/CatalogContent.tsx
@@ -6,13 +6,14 @@ import { useLanguage } from '@/shared/ui/i18n';
 import { ResourceCard } from '@/modules/resources/components/ResourceCard';
 import { Pagination } from '@/shared/ui/Pagination';
 import { useResources } from '@/hooks/useResources';
+import { parsePageParam } from '@/shared/utils/utils';
 
 const PAGE_SIZE = 12;
 
 export function CatalogContent() {
   const { locale, direction, t } = useLanguage();
   const searchParams = useSearchParams();
-  const page = Math.max(1, parseInt(searchParams.get('page') || '1', 10) || 1);
+  const page = parsePageParam(searchParams.get('page'));
   const { data, error, isLoading } = useResources({ page, page_size: PAGE_SIZE });
   const resources = data?.results ?? [];
 

--- a/src/shared/ui/Pagination.tsx
+++ b/src/shared/ui/Pagination.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useLanguage } from '@/shared/ui/i18n';
+import { parsePageParam } from '@/shared/utils/utils';
 
 interface PaginationProps {
   count: number;
@@ -13,7 +14,7 @@ export function Pagination({ count, pageSize = 12 }: PaginationProps) {
   const searchParams = useSearchParams();
   const { locale } = useLanguage();
   const totalPages = Math.ceil(count / pageSize);
-  const currentPage = parseInt(searchParams.get('page') || '1', 10);
+  const currentPage = parsePageParam(searchParams.get('page'));
 
   if (totalPages <= 1) return null;
 

--- a/src/shared/utils/utils.ts
+++ b/src/shared/utils/utils.ts
@@ -1,3 +1,9 @@
+/** Parse a `page` query param into a valid 1-indexed page number, falling back to 1 for missing/invalid/non-positive values */
+export function parsePageParam(value: string | null): number {
+  const parsed = parseInt(value ?? '1', 10);
+  return Number.isFinite(parsed) && parsed >= 1 ? parsed : 1;
+}
+
 /** Format an ISO date string to a readable date in the given locale */
 export function formatDate(dateString: string, locale: 'ar' | 'en' = 'ar'): string {
   const date = new Date(dateString);


### PR DESCRIPTION
Closes #146
- CatalogContent now reads the page query param and passes page/page_size to useResources()
- render the existing Pagination component below the results grid, wired to the API response count
- add CatalogContent.test.tsx covering page-param parsing, invalid page fallback, and pagination visibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pagination to the catalog, displaying up to 12 resources per page.
  * Catalog pages can now be selected through the page query parameter.
  * Added navigation controls for browsing multiple pages of resources.

* **Bug Fixes**
  * Added fallback handling for invalid or missing page selections.
  * Pagination controls are hidden when results fit on a single page or no resources are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->