### PR TITLE
Fix: prevent stored XSS in JsonPreview via dangerouslySetInnerHTML

### DIFF
--- a/src/__tests__/JsonPreview.test.tsx
+++ b/src/__tests__/JsonPreview.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { JsonPreview } from '@/modules/resources/components/preview/JsonPreview';
+
+describe('JsonPreview', () => {
+  it('renders nothing when there is no json_content', () => {
+    const { container } = render(<JsonPreview data={{}} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders formatted, syntax-highlighted JSON', () => {
+    render(<JsonPreview data={{ json_content: '{"name":"tafsir","count":3,"active":true,"note":null}' }} />);
+    expect(screen.getByText(/"name":/)).toBeInTheDocument();
+    expect(screen.getByText('"tafsir"')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('falls back to a plain <pre> block for invalid JSON', () => {
+    render(<JsonPreview data={{ json_content: 'not valid json' }} />);
+    expect(screen.getByText('not valid json')).toBeInTheDocument();
+  });
+
+  // Regression test: json_content is publisher-supplied and was previously
+  // injected via dangerouslySetInnerHTML with unescaped string values,
+  // allowing stored XSS (e.g. a string value containing an <img onerror>
+  // tag would execute for every visitor viewing the resource preview).
+  it('never renders HTML markup embedded in a JSON string value', () => {
+    const payload = '<img src=x onerror=alert(1)>';
+    const { container } = render(
+      <JsonPreview data={{ json_content: JSON.stringify({ x: payload }) }} />
+    );
+
+    // The payload must appear as literal, visible text...
+    expect(container.textContent).toContain(payload);
+    // ...and must never be parsed into a real <img> element.
+    expect(container.querySelector('img')).toBeNull();
+  });
+});

--- a/src/modules/resources/components/preview/JsonPreview.tsx
+++ b/src/modules/resources/components/preview/JsonPreview.tsx
@@ -6,44 +6,71 @@ interface JsonPreviewProps {
   };
 }
 
+const TOKEN_PATTERN =
+  /("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)/g;
+
+function classifyToken(match: string): string {
+  if (/^"/.test(match)) {
+    return /:$/.test(match)
+      ? 'text-[var(--accent-primary)] font-semibold'
+      : 'text-[var(--success)]';
+  }
+  if (/true|false/.test(match)) return 'text-[var(--error)]';
+  if (/null/.test(match)) return 'text-[var(--text-muted)]';
+  return 'text-[var(--text-primary)]';
+}
+
+// Splits a formatted JSON line into plain-text and token segments and
+// renders each as its own text node/span - never as raw HTML, so JSON
+// string values (which may come from user/publisher input) can't be
+// interpreted as markup no matter what characters they contain.
+function highlightLine(line: string, key: number): React.ReactNode {
+  const parts: React.ReactNode[] = [];
+  let lastIndex = 0;
+  let partIndex = 0;
+
+  for (const match of line.matchAll(TOKEN_PATTERN)) {
+    const [token] = match;
+    const start = match.index ?? 0;
+    if (start > lastIndex) {
+      parts.push(line.slice(lastIndex, start));
+    }
+    parts.push(
+      <span key={partIndex++} className={classifyToken(token)}>
+        {token}
+      </span>
+    );
+    lastIndex = start + token.length;
+  }
+  if (lastIndex < line.length) {
+    parts.push(line.slice(lastIndex));
+  }
+
+  return <div key={key}>{parts}</div>;
+}
+
 function SyntaxHighlight({ json }: { json: string }): React.ReactNode {
+  let lines: string[] | null = null;
   try {
     const parsed = JSON.parse(json);
-    const formatted = JSON.stringify(parsed, null, 2);
-    const lines = formatted.split('\n');
-
-    return (
-      <pre className="text-xs font-mono overflow-x-auto">
-        {lines.map((line, i) => {
-          const highlighted = line.replace(
-            /("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)/g,
-            (match) => {
-              let cls = 'text-[var(--text-primary)]';
-              if (/^"/.test(match)) {
-                cls = /:$/.test(match)
-                  ? 'text-[var(--accent-primary)] font-semibold'
-                  : 'text-[var(--success)]';
-              } else if (/true|false/.test(match)) {
-                cls = 'text-[var(--error)]';
-              } else if (/null/.test(match)) {
-                cls = 'text-[var(--text-muted)]';
-              }
-              return `<span class="${cls}">${match}</span>`;
-            }
-          );
-          return (
-            <div key={i} dangerouslySetInnerHTML={{ __html: highlighted }} />
-          );
-        })}
-      </pre>
-    );
+    lines = JSON.stringify(parsed, null, 2).split('\n');
   } catch {
+    lines = null;
+  }
+
+  if (lines === null) {
     return (
       <pre className="text-xs font-mono text-[var(--text-muted)] overflow-x-auto">
         {json}
       </pre>
     );
   }
+
+  return (
+    <pre className="text-xs font-mono overflow-x-auto">
+      {lines.map((line, i) => highlightLine(line, i))}
+    </pre>
+  );
 }
 
 export function JsonPreview({ data }: JsonPreviewProps) {


### PR DESCRIPTION
json_content is publisher-supplied. The syntax highlighter built an HTML string by wrapping regex-matched tokens in <span> without escaping the token contents, then injected it with dangerouslySetInnerHTML - a JSON string value containing markup (e.g. an <img onerror=...> tag) would execute for every visitor viewing that resource's preview.

- rewrite the highlighter to build React nodes/spans directly per token instead of an HTML string, so string content is always rendered as text and can never be parsed as markup
- also fixes a pre-existing react-hooks/error-boundaries lint error by separating JSON.parse (try/catch) from JSX construction
- add JsonPreview.test.tsx, including a regression test with an <img onerror> payload asserting it renders as literal text and no <img> element is created