### PR TITLE
adding aria-label and aria-current to pagination buttons

### DIFF
--- a/src/__tests__/Pagination.test.tsx
+++ b/src/__tests__/Pagination.test.tsx
@@ -33,7 +33,7 @@ describe('Pagination', () => {
     mockSearchParams = new URLSearchParams('page=not-a-number');
     renderWithProvider(<Pagination count={30} pageSize={12} />);
 
-    expect(screen.getByRole('button', { name: 'page 1' })).toHaveClass('bg-[var(--accent-primary)]');
+    expect(screen.getByRole('button', { name: 'Page 1' })).toHaveClass('bg-[var(--accent-primary)]');
     expect(screen.getByRole('button', { name: /prev/i })).toBeDisabled();
 
     fireEvent.click(screen.getByRole('button', { name: /next/i }));

--- a/src/__tests__/Pagination.test.tsx
+++ b/src/__tests__/Pagination.test.tsx
@@ -33,7 +33,7 @@ describe('Pagination', () => {
     mockSearchParams = new URLSearchParams('page=not-a-number');
     renderWithProvider(<Pagination count={30} pageSize={12} />);
 
-    expect(screen.getByRole('button', { name: '1' })).toHaveClass('bg-[var(--accent-primary)]');
+    expect(screen.getByRole('button', { name: 'page 1' })).toHaveClass('bg-[var(--accent-primary)]');
     expect(screen.getByRole('button', { name: /prev/i })).toBeDisabled();
 
     fireEvent.click(screen.getByRole('button', { name: /next/i }));

--- a/src/shared/ui/Pagination.tsx
+++ b/src/shared/ui/Pagination.tsx
@@ -70,6 +70,8 @@ export function Pagination({ count, pageSize = 12 }: PaginationProps) {
           ) : (
             <button
               key={page}
+              aria-label={locale === "ar" ? `الصفحة ${page}` : `Page ${page}`}
+              aria-current={currentPage === page ? "page" : undefined}
               onClick={() => goToPage(page as number)}
               className={`w-9 h-9 rounded-lg text-sm font-heading transition-colors ${
                 page === currentPage


### PR DESCRIPTION
Fixes #174

I added aria-label and aria-current to pagination buttons for better accessibility. Now screen readers announce each page button with a clear label and correctly identify the current page.
I also made the aria-label support two languages (Arabic and English), matching the existing pattern used for the Prev/Next labels in this file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added localized labels to pagination buttons for screen readers.
  * Marked the currently selected page for assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->