### PR TITLE
docs: document publisher-scope limitation on AccessRequests (#159)

### DIFF
--- a/payload-backend/src/collections/AccessRequests.ts
+++ b/payload-backend/src/collections/AccessRequests.ts
@@ -34,6 +34,8 @@ const canWritePublisherNotes: FieldAccess = ({ req }) => {
   return req.user.role === 'admin' || req.user.role === 'publisher'
 }
 
+// Note: AccessRequests only applies to Payload-sourced resources.
+// CMS- and mock-sourced resources have no real owner relationship to notify or approve requests.
 export const AccessRequests: CollectionConfig = {
   slug: 'access-requests',
   access: {


### PR DESCRIPTION
Fixes #159

- Added a comment in AccessRequests.ts clarifying that AccessRequests only applies to Payload-sourced resources (CMS/mock resources have no real owner to notify/approve).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that access requests apply to Payload-sourced resources.
  * Documented limitations for CMS and mock resources, which lack owner relationships for approvals or notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->