### PR TITLE
Feat: add type/license filtering to resource catalog (#149)

### DIFF
--- a/src/__tests__/CatalogContent.test.tsx
+++ b/src/__tests__/CatalogContent.test.tsx
@@ -13,6 +13,7 @@ vi.mock('@/hooks/useResources', () => ({
 
 vi.mock('next/navigation', () => ({
   useSearchParams: () => mockSearchParams,
+  usePathname: () => '/resources',
   useRouter: () => ({ push: mockPush }),
 }));
 

--- a/src/__tests__/FilterPanel.test.tsx
+++ b/src/__tests__/FilterPanel.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import { FilterPanel } from '@/modules/resources/components/FilterPanel';
+import { LanguageProvider } from '@/shared/ui/i18n/LanguageContext';
+
+let mockSearchParams = new URLSearchParams();
+const mockPush = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => mockSearchParams,
+  usePathname: () => '/resources',
+  useRouter: () => ({ push: mockPush }),
+}));
+
+function renderWithProvider(ui: React.ReactElement) {
+  localStorage.setItem('ratq_locale', 'en');
+  const result = render(<LanguageProvider>{ui}</LanguageProvider>);
+  act(() => {});
+  return result;
+}
+
+describe('FilterPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
+  });
+
+  it('pushes a type filter onto the URL when a type is selected', () => {
+    renderWithProvider(<FilterPanel />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Library' }));
+
+    expect(mockPush).toHaveBeenCalledWith('/resources?type=library', { scroll: false });
+  });
+
+  it('removes the type filter when the active type is clicked again', () => {
+    mockSearchParams = new URLSearchParams('type=library');
+    renderWithProvider(<FilterPanel />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Library' }));
+
+    expect(mockPush).toHaveBeenCalledWith('/resources?', { scroll: false });
+  });
+
+  it('combines type and license filters when both are active', () => {
+    mockSearchParams = new URLSearchParams('type=library');
+    renderWithProvider(<FilterPanel />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'MIT' }));
+
+    expect(mockPush).toHaveBeenCalledWith('/resources?type=library&license=MIT', { scroll: false });
+  });
+
+  it('resets the page param when a filter changes', () => {
+    mockSearchParams = new URLSearchParams('page=3');
+    renderWithProvider(<FilterPanel />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Library' }));
+
+    expect(mockPush).toHaveBeenCalledWith('/resources?type=library', { scroll: false });
+  });
+
+  it('clears all active filters when "Clear all" is clicked', () => {
+    mockSearchParams = new URLSearchParams('type=library&license=MIT');
+    renderWithProvider(<FilterPanel />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear all' }));
+
+    expect(mockPush).toHaveBeenCalledWith('/resources?', { scroll: false });
+  });
+
+  it('does not show "Clear all" when no filters are active', () => {
+    renderWithProvider(<FilterPanel />);
+    expect(screen.queryByRole('button', { name: 'Clear all' })).not.toBeInTheDocument();
+  });
+
+  it('shows "Clear all" when a filter is active', () => {
+    mockSearchParams = new URLSearchParams('type=library');
+    renderWithProvider(<FilterPanel />);
+    expect(screen.getByRole('button', { name: 'Clear all' })).toBeInTheDocument();
+  });
+});

--- a/src/app/resources/CatalogContent.tsx
+++ b/src/app/resources/CatalogContent.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { useLanguage } from '@/shared/ui/i18n';
 import { ResourceCard } from '@/modules/resources/components/ResourceCard';
+import { FilterPanel } from '@/modules/resources/components/FilterPanel';
 import { Pagination } from '@/shared/ui/Pagination';
 import { useResources } from '@/hooks/useResources';
 import { parsePageParam } from '@/shared/utils/utils';
@@ -14,7 +15,9 @@ export function CatalogContent() {
   const { locale, direction, t } = useLanguage();
   const searchParams = useSearchParams();
   const page = parsePageParam(searchParams.get('page'));
-  const { data, error, isLoading } = useResources({ page, page_size: PAGE_SIZE });
+  const type = searchParams.get('type') ?? undefined;
+  const license = searchParams.get('license') ?? undefined;
+  const { data, error, isLoading } = useResources({ page, page_size: PAGE_SIZE, type, license });
   const resources = data?.results ?? [];
 
   return (
@@ -31,32 +34,38 @@ export function CatalogContent() {
           </p>
         </section>
 
-        {isLoading ? (
-          <section className="mt-7 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3" aria-busy="true">
-            {Array.from({ length: 6 }).map((_, index) => (
-              <div key={index} className="skeleton min-h-[305px] rounded-[13px]" />
-            ))}
-          </section>
-        ) : error ? (
-          <section className="mt-7 rounded-[18px] border border-[#e7e7e7] bg-[#fafafa] px-6 py-16 text-center">
-            <p className="text-lg font-black">{t.catalog.error.title}</p>
-            <p className="mt-2 text-sm text-[#8b8b8b]">{t.catalog.error.subtitle}</p>
-          </section>
-        ) : resources.length === 0 ? (
-          <section className="mt-7 rounded-[18px] border border-[#e7e7e7] bg-[#fafafa] px-6 py-16 text-center">
-            <p className="text-lg font-black">{t.catalog.noResources.title}</p>
-            <p className="mt-2 text-sm text-[#8b8b8b]">{t.catalog.noResources.subtitle}</p>
-          </section>
-        ) : (
-          <>
-            <section className="mt-7 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
-              {resources.map((resource) => (
-                <ResourceCard key={resource.id} resource={resource} />
-              ))}
-            </section>
-            <Pagination count={data?.count ?? 0} pageSize={PAGE_SIZE} />
-          </>
-        )}
+        <div className="mt-7 flex flex-col gap-6 sm:flex-row sm:items-start">
+          <FilterPanel />
+
+          <div className="min-w-0 flex-1">
+            {isLoading ? (
+              <section className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3" aria-busy="true">
+                {Array.from({ length: 6 }).map((_, index) => (
+                  <div key={index} className="skeleton min-h-[305px] rounded-[13px]" />
+                ))}
+              </section>
+            ) : error ? (
+              <section className="rounded-[18px] border border-[#e7e7e7] bg-[#fafafa] px-6 py-16 text-center">
+                <p className="text-lg font-black">{t.catalog.error.title}</p>
+                <p className="mt-2 text-sm text-[#8b8b8b]">{t.catalog.error.subtitle}</p>
+              </section>
+            ) : resources.length === 0 ? (
+              <section className="rounded-[18px] border border-[#e7e7e7] bg-[#fafafa] px-6 py-16 text-center">
+                <p className="text-lg font-black">{t.catalog.noResources.title}</p>
+                <p className="mt-2 text-sm text-[#8b8b8b]">{t.catalog.noResources.subtitle}</p>
+              </section>
+            ) : (
+              <>
+                <section className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+                  {resources.map((resource) => (
+                    <ResourceCard key={resource.id} resource={resource} />
+                  ))}
+                </section>
+                <Pagination count={data?.count ?? 0} pageSize={PAGE_SIZE} />
+              </>
+            )}
+          </div>
+        </div>
 
         <section className="mt-24 overflow-hidden rounded-[24px] bg-[linear-gradient(112deg,#edf1f1_15%,#dbeaf6_100%)] px-7 sm:px-12">
           <div className="grid items-stretch md:min-h-[340px] gap-8 md:grid-cols-[330px_1fr]" dir="ltr">

--- a/src/modules/resources/components/FilterPanel.tsx
+++ b/src/modules/resources/components/FilterPanel.tsx
@@ -13,13 +13,14 @@ const RESOURCE_TYPES: ResourceType[] = [
 
 // Free-form strings from resource data (not an enum in src/types/resource.ts).
 // Sourced from observed values across mock-data.ts / cms.ts / payload.ts.
+// SPDX-style license identifiers are conventionally left untranslated.
 const LICENSES = [
   'MIT', 'Apache-2.0', 'GPL-3.0', 'BSD-3-Clause',
   'CC-BY-4.0', 'CC-BY-SA-4.0', 'CC-BY-SA-3.0', 'CC-BY-NC-4.0', 'custom',
 ];
 
 export function FilterPanel() {
-  const { direction } = useLanguage();
+  const { direction, t } = useLanguage();
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -51,20 +52,20 @@ export function FilterPanel() {
   return (
     <aside className="w-full shrink-0 sm:w-56" dir={direction}>
       <div className="flex items-center justify-between">
-        <h2 className="text-sm font-black">Filters</h2>
+        <h2 className="text-sm font-black">{t.catalog.filters.title}</h2>
         {hasActiveFilters && (
           <button
             type="button"
             onClick={clearAll}
             className="text-xs font-bold text-[#8b8b8b] underline hover:text-black"
           >
-            Clear all
+            {t.catalog.filters.clearAll}
           </button>
         )}
       </div>
 
       <fieldset className="mt-5">
-        <legend className="text-xs font-black text-[#8b8b8b]">Type</legend>
+        <legend className="text-xs font-black text-[#8b8b8b]">{t.catalog.filters.type}</legend>
         <div className="mt-2 flex flex-col gap-2">
           {RESOURCE_TYPES.map((type) => {
             const isActive = activeType === type;
@@ -74,11 +75,11 @@ export function FilterPanel() {
                 type="button"
                 aria-pressed={isActive}
                 onClick={() => updateParam('type', isActive ? '' : type)}
-                className={`w-fit rounded-full px-3 py-1 text-left text-sm capitalize transition ${
+                className={`w-fit rounded-full px-3 py-1 text-left text-sm transition ${
                   isActive ? 'bg-black font-bold text-white' : 'text-[#4a4a4a] hover:bg-[#f0f0f0]'
                 }`}
               >
-                {type}
+                {t.catalog.types[type]}
               </button>
             );
           })}
@@ -86,7 +87,7 @@ export function FilterPanel() {
       </fieldset>
 
       <fieldset className="mt-6">
-        <legend className="text-xs font-black text-[#8b8b8b]">License</legend>
+        <legend className="text-xs font-black text-[#8b8b8b]">{t.catalog.filters.license}</legend>
         <div className="mt-2 flex flex-col gap-2">
           {LICENSES.map((license) => {
             const isActive = activeLicense === license;

--- a/src/modules/resources/components/FilterPanel.tsx
+++ b/src/modules/resources/components/FilterPanel.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useRouter, usePathname, useSearchParams } from 'next/navigation';
+import { useLanguage } from '@/shared/ui/i18n';
+import type { ResourceType } from '@/types/resource';
+
+// Static list matching the ResourceType union in src/types/resource.ts.
+// Kept here (not imported) since ResourceType is a type, not a runtime value.
+const RESOURCE_TYPES: ResourceType[] = [
+  'library', 'sdk', 'dataset', 'api', 'tafsir', 'audio', 'pdf', 'json',
+  'recitation', 'mushaf', 'program', 'linguistic', 'translation', 'font', 'search', 'tajweed',
+];
+
+// Free-form strings from resource data (not an enum in src/types/resource.ts).
+// Sourced from observed values across mock-data.ts / cms.ts / payload.ts.
+const LICENSES = [
+  'MIT', 'Apache-2.0', 'GPL-3.0', 'BSD-3-Clause',
+  'CC-BY-4.0', 'CC-BY-SA-4.0', 'CC-BY-SA-3.0', 'CC-BY-NC-4.0', 'custom',
+];
+
+export function FilterPanel() {
+  const { direction } = useLanguage();
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const activeType = searchParams.get('type') ?? '';
+  const activeLicense = searchParams.get('license') ?? '';
+  const hasActiveFilters = Boolean(activeType || activeLicense);
+
+  function updateParam(key: 'type' | 'license', value: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value) {
+      params.set(key, value);
+    } else {
+      params.delete(key);
+    }
+    // Any filter change should reset pagination back to page 1.
+    params.delete('page');
+    router.push(`${pathname}?${params.toString()}`, { scroll: false });
+  }
+
+  function clearAll() {
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete('type');
+    params.delete('license');
+    params.delete('page');
+    router.push(`${pathname}?${params.toString()}`, { scroll: false });
+  }
+
+  return (
+    <aside className="w-full shrink-0 sm:w-56" dir={direction}>
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-black">Filters</h2>
+        {hasActiveFilters && (
+          <button
+            type="button"
+            onClick={clearAll}
+            className="text-xs font-bold text-[#8b8b8b] underline hover:text-black"
+          >
+            Clear all
+          </button>
+        )}
+      </div>
+
+      <fieldset className="mt-5">
+        <legend className="text-xs font-black text-[#8b8b8b]">Type</legend>
+        <div className="mt-2 flex flex-col gap-2">
+          {RESOURCE_TYPES.map((type) => {
+            const isActive = activeType === type;
+            return (
+              <button
+                key={type}
+                type="button"
+                aria-pressed={isActive}
+                onClick={() => updateParam('type', isActive ? '' : type)}
+                className={`w-fit rounded-full px-3 py-1 text-left text-sm capitalize transition ${
+                  isActive ? 'bg-black font-bold text-white' : 'text-[#4a4a4a] hover:bg-[#f0f0f0]'
+                }`}
+              >
+                {type}
+              </button>
+            );
+          })}
+        </div>
+      </fieldset>
+
+      <fieldset className="mt-6">
+        <legend className="text-xs font-black text-[#8b8b8b]">License</legend>
+        <div className="mt-2 flex flex-col gap-2">
+          {LICENSES.map((license) => {
+            const isActive = activeLicense === license;
+            return (
+              <button
+                key={license}
+                type="button"
+                aria-pressed={isActive}
+                onClick={() => updateParam('license', isActive ? '' : license)}
+                className={`w-fit rounded-full px-3 py-1 text-left text-sm transition ${
+                  isActive ? 'bg-black font-bold text-white' : 'text-[#4a4a4a] hover:bg-[#f0f0f0]'
+                }`}
+              >
+                {license}
+              </button>
+            );
+          })}
+        </div>
+      </fieldset>
+    </aside>
+  );
+}

--- a/src/shared/ui/i18n/messages/ar.json
+++ b/src/shared/ui/i18n/messages/ar.json
@@ -130,7 +130,8 @@
       "allLicenses": "الكل",
       "itqanBadge": "موثق بإتقان",
       "verifiedOnly": "الموثق فقط",
-      "notVerified": "غير موثق"
+      "notVerified": "غير موثق",
+      "clearAll": "مسح الكل"
     },
     "types": {
       "library": "مكتبة",

--- a/src/shared/ui/i18n/messages/en.json
+++ b/src/shared/ui/i18n/messages/en.json
@@ -130,7 +130,8 @@
       "allLicenses": "All",
       "itqanBadge": "Itqan Verified",
       "verifiedOnly": "Verified only",
-      "notVerified": "Not verified"
+      "notVerified": "Not verified",
+      "clearAll": "Clear all"
     },
     "types": {
       "library": "Library",


### PR DESCRIPTION
Fix #149

- Add FilterPanel component with single-select type/license filters
- Filters sync to URL query params (?type=...&license=...) and reset pagination on change
- Wire type/license from URL into useResources in CatalogContent
- Add 'Clear all' to reset active filters
- Fix next/navigation test mock missing usePathname

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added filters for resource type and license to the resources catalog.
  * Filter selections are reflected in the URL and reset pagination automatically.
  * Added a “Clear all” option to remove active filters.

* **Accessibility**
  * Active filter options now provide clear selected-state feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->