### PR TITLE
Fix: wrap resource detail page in withEdgeCache (#176)

### DIFF
--- a/src/app/resources/[slug]/page.tsx
+++ b/src/app/resources/[slug]/page.tsx
@@ -1,10 +1,39 @@
+import { cache } from 'react';
 import { notFound } from 'next/navigation';
 import { resourceAggregator } from '@/modules/resources/infrastructure/repositories/aggregate';
+import { withEdgeCache } from '@/shared/infrastructure/edge-cache';
 import { ResourceDetailClient } from './ResourceDetailClient';
+import type { Resource } from '@/types/resource';
 
 // Required by @cloudflare/next-on-pages: non-static routes must opt into the
 // edge runtime or the CF Pages build fails.
 export const runtime = 'edge';
+
+// Page components run in the same edge runtime as /api/resources/[slug] but
+// previously called resourceAggregator.get() directly, bypassing the
+// Workers Cache API layer that route uses (see withEdgeCache) - Next's
+// `next: { revalidate }` fetch cache isn't reliably honored on this runtime
+// (see edge-cache.ts comment), so every page visit re-hit the CMS uncached.
+// This wraps the same aggregator call in withEdgeCache using a synthetic
+// cache-key Request (never actually sent over the network) so the page
+// benefits from the same cache as the API route, without an extra self-fetch
+// round-trip or needing a base-URL env var.
+// Wrapped in React's cache() so generateMetadata and the page component
+// (which both need the same resource) share one call per request instead
+// of hitting withEdgeCache's cache.match twice.
+const getCachedResource = cache(async (slug: string): Promise<Resource | null> => {
+  const cacheKeyRequest = new Request(`https://cache-key.internal/resources/${slug}`);
+  const response = await withEdgeCache(cacheKeyRequest, async () => {
+    const resource = await resourceAggregator.get(slug);
+    return new Response(JSON.stringify(resource ?? null), {
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=60',
+      },
+    });
+  });
+  return response.json();
+});
 
 export async function generateMetadata({
   params,
@@ -12,9 +41,8 @@ export async function generateMetadata({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const resource = await resourceAggregator.get(slug);
+  const resource = await getCachedResource(slug);
   if (!resource) return { title: 'Resource Not Found' };
-
   return {
     title: resource.name,
     description: resource.description.slice(0, 160),
@@ -27,11 +55,9 @@ export default async function ResourceDetailPage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const resource = await resourceAggregator.get(slug);
-
+  const resource = await getCachedResource(slug);
   if (!resource) {
     notFound();
   }
-
   return <ResourceDetailClient resource={resource} />;
 }


### PR DESCRIPTION
**Fix** #176 
Root cause: /resources/[slug] called resourceAggregator.get() directly, bypassing the Workers Cache API layer that /api/resources/[slug] uses. Next's fetch revalidate cache isn't reliably honored on Cloudflare's edge runtime (see edge-cache.ts comment), so every detail page visit re-hit the CMS uncached.

Wraps the same aggregator call in withEdgeCache via a synthetic cache-key Request, and in React's cache() so generateMetadata and the page component share one call per request.

Measurements (prod, beta.ratq.itqan.dev):
- API detail endpoint (already cached): 4.38s -> 0.23s -> 0.25s
- Page before fix: 2.0s -> 1.4s -> 1.7s (never benefited from cache)
- Page after fix (local repro): 0.26s -> 0.10s -> 0.10s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved resource detail page loading through more efficient caching.
  * Reduced duplicate resource lookups when displaying page content and metadata.
* **Bug Fixes**
  * Preserved existing not-found behavior for unavailable resources.
  * Improved consistency between resource page content and its metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->