### PR TITLE
feat/added sort select dropdown in resourses page

### DIFF
--- a/src/__tests__/SortSelect.test.tsx
+++ b/src/__tests__/SortSelect.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import SortSelect from '@/modules/resources/components/SortSelect';
+import { LanguageProvider } from '@/shared/ui/i18n/LanguageContext';
+
+let mockSearchParams = new URLSearchParams();
+const mockPush = vi.fn();
+
+vi.mock('next/navigation', () => ({
+    useSearchParams: () => mockSearchParams,
+    usePathname: () => '/resources',
+    useRouter: () => ({ push: mockPush }),
+}));
+
+function renderWithProvider(ui: React.ReactElement) {
+    localStorage.setItem('ratq_locale', 'en');
+    const result = render(<LanguageProvider>{ui}</LanguageProvider>);
+    act(() => { });
+    return result;
+}
+
+describe('SortSelect', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockSearchParams = new URLSearchParams();
+    });
+
+    it('pushes the sort param onto the URL when an option is selected', () => {
+        renderWithProvider(<SortSelect />);
+
+        fireEvent.change(screen.getByRole('combobox'), { target: { value: 'downloads' } });
+
+        expect(mockPush).toHaveBeenCalledWith('/resources?sort=downloads', { scroll: false });
+    });
+
+    it('resets the page param when the sort changes', () => {
+        mockSearchParams = new URLSearchParams('page=3');
+        renderWithProvider(<SortSelect />);
+
+        fireEvent.change(screen.getByRole('combobox'), { target: { value: 'newest' } });
+
+        expect(mockPush).toHaveBeenCalledWith('/resources?sort=newest', { scroll: false });
+    });
+
+    it('preserves other active params when sort changes', () => {
+        mockSearchParams = new URLSearchParams('type=library&license=MIT');
+        renderWithProvider(<SortSelect />);
+
+        fireEvent.change(screen.getByRole('combobox'), { target: { value: 'name_asc' } });
+
+        expect(mockPush).toHaveBeenCalledWith('/resources?type=library&license=MIT&sort=name_asc', { scroll: false });
+    });
+
+    it('defaults to relevance when no sort param is in the URL', () => {
+        renderWithProvider(<SortSelect />);
+
+        expect(screen.getByRole('combobox')).toHaveValue('relevance');
+    });
+
+    it('reflects the active sort value from the URL', () => {
+        mockSearchParams = new URLSearchParams('sort=oldest');
+        renderWithProvider(<SortSelect />);
+
+        expect(screen.getByRole('combobox')).toHaveValue('oldest');
+    });
+});

--- a/src/app/resources/CatalogContent.tsx
+++ b/src/app/resources/CatalogContent.tsx
@@ -8,6 +8,8 @@ import { FilterPanel } from '@/modules/resources/components/FilterPanel';
 import { Pagination } from '@/shared/ui/Pagination';
 import { useResources } from '@/hooks/useResources';
 import { parsePageParam } from '@/shared/utils/utils';
+import SortSelect from '@/modules/resources/components/SortSelect';
+import { SortOption } from '@/types/resource';
 
 const PAGE_SIZE = 12;
 
@@ -16,9 +18,10 @@ export function CatalogContent() {
   const searchParams = useSearchParams();
   const page = parsePageParam(searchParams.get('page'));
   const type = searchParams.get('type') ?? undefined;
+  const sort = (searchParams.get('sort') as SortOption) ?? undefined;
   const license = searchParams.get('license') ?? undefined;
   const search = searchParams.get('search') ?? '';
-  const { data, error, isLoading } = useResources({ page, page_size: PAGE_SIZE, type, license, search });
+  const { data, error, isLoading } = useResources({ page, page_size: PAGE_SIZE, type, license, search, sort });
   const resources = data?.results ?? [];
   const router = useRouter();
 
@@ -75,10 +78,11 @@ export function CatalogContent() {
         </section>
 
         <div className="mt-7 flex flex-col gap-6 sm:flex-row sm:items-start">
-          
+
           <FilterPanel />
 
           <div className="min-w-0 flex-1">
+            <SortSelect />
             {isLoading ? (
               <section className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3" aria-busy="true">
                 {Array.from({ length: 6 }).map((_, index) => (

--- a/src/modules/resources/components/SortSelect.tsx
+++ b/src/modules/resources/components/SortSelect.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useLanguage } from '@/shared/ui/i18n';
+import { SortOption } from '@/types/resource';
+import { usePathname, useSearchParams, useRouter } from 'next/navigation';
+
+const SORT_OPTIONS: SortOption[] = ['relevance', 'downloads', 'newest', 'oldest', 'name_asc', 'name_desc'];
+
+export default function SortSelect() {
+  const { direction, t } = useLanguage();
+
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const activeSort = searchParams.get('sort') ?? 'relevance';
+
+  function updateParam(key: 'sort', value: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value) {
+      params.set(key, value);
+    } else {
+      params.delete(key);
+    }
+    // Any sort change should reset pagination back to page 1.
+    params.delete('page');
+    router.push(`${pathname}?${params.toString()}`, { scroll: false });
+  }
+
+  return (
+    <div className='flex items-center gap-3 mb-6' dir={direction}>
+      <label htmlFor='sort' className='text-sm font-black text-[#8b8b8b]'>
+        {t.catalog.sort.by}
+      </label>
+      <div className='relative'>
+        <select
+          id='sort'
+          name='sort'
+          onChange={(e) => updateParam('sort', e.target.value)}
+          value={activeSort}
+          className='appearance-none rounded-full border border-[#e7e7e7] bg-white py-2 pe-9 ps-4 text-sm font-bold text-black transition hover:border-[#c7c7c7] focus:border-black focus:outline-none'
+        >
+          {SORT_OPTIONS.map((option) => (
+            <option key={option} value={option}>
+              {t.catalog.sort.options[option]}
+            </option>
+          ))}
+        </select>
+        <svg
+          className='pointer-events-none absolute end-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[#8b8b8b]'
+          fill='none'
+          viewBox='0 0 24 24'
+          stroke='currentColor'
+          strokeWidth={2.5}
+        >
+          <path strokeLinecap='round' strokeLinejoin='round' d='M19 9l-7 7-7-7' />
+        </svg>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What this does
Adds a sort dropdown to the resources catalog page, letting users reorder 
results by relevance, most downloaded, newest, oldest, or name (A-Z / Z-A).

Closes #148

## Changes
- New `SortSelect` component with a `<select>` dropdown, styled to match 
  the existing filter panel
- Selecting a sort option updates the `sort` query param in the URL 
  (following the same pattern already used by `FilterPanel` for `type`/`license`)
- Changing sort resets pagination back to page 1
- `CatalogContent` now reads `sort` from the URL and passes it to `useResources`
- Added tests covering: pushing the sort param, resetting page, preserving 
  other active filters, and reflecting the active sort value on load

## Notes
- Tested manually: selecting each option updates the URL and reorders 
  results, and the sort persists after a page refresh