### PR TITLE
feat: add GitHub repo preview with commits and topics (#189)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,5 @@ NEXT_PUBLIC_CMS_GALLERY_URL=https://cms.itqan.dev/gallery/asset
 NEXT_PUBLIC_PAYLOAD_API_URL=https://api.ratq.itqan.dev/api
 # Set to 'true' to include RATQ's mock resources in the public catalog (local dev/demo only, off by default)
 # NEXT_PUBLIC_INCLUDE_MOCK_SOURCE=true
+# Server-only GitHub PAT for resource-detail repo previews (commits + topics). Never expose as NEXT_PUBLIC_*.
+GITHUB_API_TOKEN=

--- a/src/__tests__/ResourceDetailPage.test.tsx
+++ b/src/__tests__/ResourceDetailPage.test.tsx
@@ -14,7 +14,11 @@ vi.mock('next/navigation', () => ({
 }));
 
 vi.mock('@/app/resources/[slug]/ResourceDetailClient', () => ({
-  ResourceDetailClient: (_props: { resource: Resource }) => null,
+  ResourceDetailClient: (_props: { resource: Resource; repoPreview: unknown }) => null,
+}));
+
+vi.mock('@/modules/resources/infrastructure/github/fetchGithubRepoPreview', () => ({
+  fetchGithubRepoPreview: vi.fn(async () => null),
 }));
 
 function createResource(overrides: Partial<Resource> = {}): Resource {

--- a/src/__tests__/fetchGithubRepoPreview.test.ts
+++ b/src/__tests__/fetchGithubRepoPreview.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchGithubRepoPreview } from '@/modules/resources/infrastructure/github/fetchGithubRepoPreview';
+
+const commitsUrl = 'https://api.github.com/repos/owner/repo/commits?per_page=5';
+const topicsUrl = 'https://api.github.com/repos/owner/repo/topics';
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+describe('fetchGithubRepoPreview', () => {
+  const originalToken = process.env.GITHUB_API_TOKEN;
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    if (originalToken === undefined) {
+      delete process.env.GITHUB_API_TOKEN;
+    } else {
+      process.env.GITHUB_API_TOKEN = originalToken;
+    }
+  });
+
+  it('returns null when GITHUB_API_TOKEN is missing', async () => {
+    delete process.env.GITHUB_API_TOKEN;
+
+    await expect(fetchGithubRepoPreview('owner', 'repo')).resolves.toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('returns null when a GitHub response is not ok', async () => {
+    process.env.GITHUB_API_TOKEN = 'test-token';
+    vi.mocked(fetch).mockImplementation(async (input) => {
+      const url = String(input);
+      if (url === commitsUrl) return jsonResponse([]);
+      return jsonResponse({ message: 'Not Found' }, false, 404);
+    });
+
+    await expect(fetchGithubRepoPreview('owner', 'repo')).resolves.toBeNull();
+  });
+
+  it('returns null when fetch throws', async () => {
+    process.env.GITHUB_API_TOKEN = 'test-token';
+    vi.mocked(fetch).mockRejectedValue(new Error('network down'));
+
+    await expect(fetchGithubRepoPreview('owner', 'repo')).resolves.toBeNull();
+  });
+
+  it('maps commits and topics on success', async () => {
+    process.env.GITHUB_API_TOKEN = 'test-token';
+    vi.mocked(fetch).mockImplementation(async (input) => {
+      const url = String(input);
+      if (url === commitsUrl) {
+        return jsonResponse([
+          {
+            sha: 'abc123def456',
+            html_url: 'https://github.com/owner/repo/commit/abc123def456',
+            commit: {
+              message: 'Fix parser\n\nMore detail',
+              author: { name: 'Ada', date: '2026-08-01T12:00:00Z' },
+            },
+            author: { login: 'ada' },
+          },
+        ]);
+      }
+      if (url === topicsUrl) {
+        return jsonResponse({ names: ['quran', 'typescript'] });
+      }
+      return jsonResponse({}, false, 404);
+    });
+
+    await expect(fetchGithubRepoPreview('owner', 'repo')).resolves.toEqual({
+      topics: ['quran', 'typescript'],
+      commits: [
+        {
+          sha: 'abc123def456',
+          message: 'Fix parser',
+          author: 'Ada',
+          date: '2026-08-01T12:00:00Z',
+          url: 'https://github.com/owner/repo/commit/abc123def456',
+        },
+      ],
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(fetch).toHaveBeenCalledWith(
+      commitsUrl,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-token',
+        }),
+        next: { revalidate: 300 },
+      }),
+    );
+  });
+});

--- a/src/__tests__/parseGithubRepoUrl.test.ts
+++ b/src/__tests__/parseGithubRepoUrl.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { parseGithubRepoUrl } from '@/modules/resources/infrastructure/github/parseGithubRepoUrl';
+
+describe('parseGithubRepoUrl', () => {
+  it('parses https://github.com/owner/repo', () => {
+    expect(parseGithubRepoUrl('https://github.com/Itqan-community/RATQ')).toEqual({
+      owner: 'Itqan-community',
+      repo: 'RATQ',
+    });
+  });
+
+  it('strips a trailing slash', () => {
+    expect(parseGithubRepoUrl('https://github.com/owner/repo/')).toEqual({
+      owner: 'owner',
+      repo: 'repo',
+    });
+  });
+
+  it('strips a .git suffix', () => {
+    expect(parseGithubRepoUrl('https://github.com/owner/repo.git')).toEqual({
+      owner: 'owner',
+      repo: 'repo',
+    });
+  });
+
+  it('strips .git and a trailing slash together', () => {
+    expect(parseGithubRepoUrl('https://github.com/owner/repo.git/')).toEqual({
+      owner: 'owner',
+      repo: 'repo',
+    });
+  });
+
+  it('returns null for http URLs', () => {
+    expect(parseGithubRepoUrl('http://github.com/owner/repo')).toBeNull();
+  });
+
+  it('returns null for non-github hosts', () => {
+    expect(parseGithubRepoUrl('https://gitlab.com/owner/repo')).toBeNull();
+    expect(parseGithubRepoUrl('https://www.github.com/owner/repo')).toBeNull();
+  });
+
+  it('returns null for extra path segments', () => {
+    expect(parseGithubRepoUrl('https://github.com/owner/repo/tree/main')).toBeNull();
+    expect(parseGithubRepoUrl('https://github.com/owner/repo/issues/189')).toBeNull();
+  });
+
+  it('returns null when owner or repo is missing', () => {
+    expect(parseGithubRepoUrl('https://github.com/owner')).toBeNull();
+    expect(parseGithubRepoUrl('https://github.com/')).toBeNull();
+  });
+
+  it('returns null for missing, empty, or invalid URLs', () => {
+    expect(parseGithubRepoUrl(null)).toBeNull();
+    expect(parseGithubRepoUrl(undefined)).toBeNull();
+    expect(parseGithubRepoUrl('')).toBeNull();
+    expect(parseGithubRepoUrl('not-a-url')).toBeNull();
+  });
+});

--- a/src/app/resources/[slug]/ResourceDetailClient.tsx
+++ b/src/app/resources/[slug]/ResourceDetailClient.tsx
@@ -3,14 +3,16 @@
 import Link from 'next/link';
 import type { ReactNode } from 'react';
 import { formatDate } from '@/shared/utils/utils';
+import { GithubRepoPreview } from '@/modules/resources/components/GithubRepoPreview';
 import { GithubStatsCard } from '@/modules/resources/components/GithubStatsCard';
 import { TrustedBySection } from '@/modules/resources/components/TrustedBySection';
 import { useLanguage } from '@/shared/ui/i18n';
-import type { Resource, ResourceType } from '@/types/resource';
+import type { GithubRepoPreview as GithubRepoPreviewData, Resource, ResourceType } from '@/types/resource';
 import arabicDescriptions from '@/shared/ui/i18n/resource-descriptions.ar.json';
 
 interface ResourceDetailClientProps {
   resource: Resource;
+  repoPreview: GithubRepoPreviewData | null;
 }
 
 const typeColors: Record<ResourceType, string> = {
@@ -44,7 +46,7 @@ function InfoItem({ icon, label, value }: { icon: ReactNode; label: string; valu
 
 const smallIcon = (path: ReactNode) => <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8}>{path}</svg>;
 
-export function ResourceDetailClient({ resource }: ResourceDetailClientProps) {
+export function ResourceDetailClient({ resource, repoPreview }: ResourceDetailClientProps) {
   const { t, locale, direction } = useLanguage();
   const arabicCopy = arabicDescriptions[resource.slug as keyof typeof arabicDescriptions];
   const localizedDescription = locale === 'ar' && arabicCopy ? arabicCopy.description : resource.description;
@@ -97,6 +99,7 @@ export function ResourceDetailClient({ resource }: ResourceDetailClientProps) {
 
             <section className="mt-6">
               <GithubStatsCard githubUrl={resource.github_url || resource.documentation_url || "#"} stats={resource.github_stats}/>
+              <GithubRepoPreview repoPreview={repoPreview} />
             </section>
           </div>
         </div>

--- a/src/app/resources/[slug]/page.tsx
+++ b/src/app/resources/[slug]/page.tsx
@@ -1,9 +1,11 @@
 import { cache } from 'react';
 import { notFound } from 'next/navigation';
 import { resourceAggregator } from '@/modules/resources/infrastructure/repositories/aggregate';
+import { fetchGithubRepoPreview } from '@/modules/resources/infrastructure/github/fetchGithubRepoPreview';
+import { parseGithubRepoUrl } from '@/modules/resources/infrastructure/github/parseGithubRepoUrl';
 import { withEdgeCache } from '@/shared/infrastructure/edge-cache';
 import { ResourceDetailClient } from './ResourceDetailClient';
-import type { Resource } from '@/types/resource';
+import type { GithubRepoPreview, Resource } from '@/types/resource';
 
 // Required by @cloudflare/next-on-pages: non-static routes must opt into the
 // edge runtime or the CF Pages build fails.
@@ -60,5 +62,11 @@ export default async function ResourceDetailPage({
   if (!resource) {
     notFound();
   }
-  return <ResourceDetailClient resource={resource} />;
+
+  const parsed = parseGithubRepoUrl(resource.github_url);
+  const repoPreview: GithubRepoPreview | null = parsed
+    ? await fetchGithubRepoPreview(parsed.owner, parsed.repo)
+    : null;
+
+  return <ResourceDetailClient resource={resource} repoPreview={repoPreview} />;
 }

--- a/src/modules/resources/components/GithubRepoPreview.tsx
+++ b/src/modules/resources/components/GithubRepoPreview.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { formatDate } from '@/shared/utils/utils';
+import { useLanguage } from '@/shared/ui/i18n';
+import type { GithubRepoPreview as GithubRepoPreviewData } from '@/types/resource';
+
+interface GithubRepoPreviewProps {
+  repoPreview: GithubRepoPreviewData | null;
+}
+
+export function GithubRepoPreview({ repoPreview }: GithubRepoPreviewProps) {
+  const { t, locale } = useLanguage();
+
+  if (!repoPreview) return null;
+
+  const copy = t.resource.detail.githubPreview;
+  const hasTopics = repoPreview.topics.length > 0;
+  const hasCommits = repoPreview.commits.length > 0;
+
+  return (
+    <section
+      className="mt-6 rounded-xl border border-[#e5e5e5] bg-white p-6 text-start"
+      aria-labelledby="github-repo-preview-title"
+    >
+      <h2 id="github-repo-preview-title" className="text-xl font-black">
+        {copy.title}
+      </h2>
+
+      {hasTopics && (
+        <div className="mt-5">
+          <h3 className="text-sm font-black">{copy.topics}</h3>
+          <ul className="mt-3 flex flex-wrap gap-2">
+            {repoPreview.topics.map((topic) => (
+              <li
+                key={topic}
+                className="rounded-full bg-[#f4f4f4] px-3 py-1 text-xs font-semibold text-[#333]"
+                dir="ltr"
+              >
+                {topic}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {hasCommits && (
+        <div className={hasTopics ? 'mt-6' : 'mt-5'}>
+          <h3 className="text-sm font-black">{copy.recentCommits}</h3>
+          <ul className="mt-3 divide-y divide-[#ededed]">
+            {repoPreview.commits.map((commit) => (
+              <li key={commit.sha} className="py-3 first:pt-0 last:pb-0">
+                <a
+                  href={commit.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm font-semibold text-[#111] hover:underline"
+                >
+                  {commit.message || commit.sha.slice(0, 7)}
+                </a>
+                <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-[#777]">
+                  <span>{commit.author}</span>
+                  <span>{formatDate(commit.date, locale)}</span>
+                  <a
+                    href={commit.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-semibold text-[#36b96b] hover:underline"
+                    dir="ltr"
+                  >
+                    {copy.viewCommit}
+                  </a>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/modules/resources/infrastructure/github/fetchGithubRepoPreview.ts
+++ b/src/modules/resources/infrastructure/github/fetchGithubRepoPreview.ts
@@ -1,0 +1,89 @@
+import type { GithubCommit, GithubRepoPreview } from '@/types/resource';
+
+interface GithubCommitAuthor {
+  name?: string;
+  date?: string;
+}
+
+interface GithubCommitResponse {
+  sha: string;
+  html_url: string;
+  commit?: {
+    message?: string;
+    author?: GithubCommitAuthor | null;
+    committer?: GithubCommitAuthor | null;
+  };
+  author?: { login?: string } | null;
+}
+
+interface GithubTopicsResponse {
+  names?: string[];
+}
+
+const GITHUB_API = 'https://api.github.com';
+const REVALIDATE = 300;
+
+function githubHeaders(token: string): HeadersInit {
+  return {
+    Accept: 'application/vnd.github+json',
+    Authorization: `Bearer ${token}`,
+    'User-Agent': 'RATQ (https://github.com/Itqan-community/RATQ)',
+  };
+}
+
+function mapCommit(item: GithubCommitResponse): GithubCommit {
+  const message = (item.commit?.message ?? '').split('\n')[0]?.trim() ?? '';
+  const author =
+    item.commit?.author?.name ||
+    item.commit?.committer?.name ||
+    item.author?.login ||
+    '';
+  const date = item.commit?.author?.date || item.commit?.committer?.date || '';
+
+  return {
+    sha: item.sha,
+    message,
+    author,
+    date,
+    url: item.html_url,
+  };
+}
+
+export async function fetchGithubRepoPreview(
+  owner: string,
+  repo: string,
+): Promise<GithubRepoPreview | null> {
+  const token = process.env.GITHUB_API_TOKEN;
+  if (!token) return null;
+
+  const encodedOwner = encodeURIComponent(owner);
+  const encodedRepo = encodeURIComponent(repo);
+  const headers = githubHeaders(token);
+
+  try {
+    const [commitsRes, topicsRes] = await Promise.all([
+      fetch(`${GITHUB_API}/repos/${encodedOwner}/${encodedRepo}/commits?per_page=5`, {
+        headers,
+        next: { revalidate: REVALIDATE },
+      }),
+      fetch(`${GITHUB_API}/repos/${encodedOwner}/${encodedRepo}/topics`, {
+        headers,
+        next: { revalidate: REVALIDATE },
+      }),
+    ]);
+
+    if (!commitsRes.ok || !topicsRes.ok) return null;
+
+    const commitsJson = (await commitsRes.json()) as GithubCommitResponse[];
+    const topicsJson = (await topicsRes.json()) as GithubTopicsResponse;
+
+    if (!Array.isArray(commitsJson)) return null;
+
+    return {
+      topics: Array.isArray(topicsJson.names) ? topicsJson.names : [],
+      commits: commitsJson.map(mapCommit),
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/modules/resources/infrastructure/github/parseGithubRepoUrl.ts
+++ b/src/modules/resources/infrastructure/github/parseGithubRepoUrl.ts
@@ -1,0 +1,29 @@
+export interface GithubRepoRef {
+  owner: string;
+  repo: string;
+}
+
+/**
+ * Accepts only https://github.com/{owner}/{repo}, optionally with a trailing
+ * slash or .git suffix. Anything else (http, other hosts, extra path) is null.
+ */
+export function parseGithubRepoUrl(url: string | null | undefined): GithubRepoRef | null {
+  if (!url) return null;
+
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'https:') return null;
+    if (parsed.hostname !== 'github.com') return null;
+
+    const parts = parsed.pathname.replace(/\/+$/, '').split('/').filter(Boolean);
+    if (parts.length !== 2) return null;
+
+    const [owner, rawRepo] = parts;
+    const repo = rawRepo.replace(/\.git$/i, '');
+    if (!owner || !repo) return null;
+
+    return { owner, repo };
+  } catch {
+    return null;
+  }
+}

--- a/src/shared/ui/i18n/messages/ar.json
+++ b/src/shared/ui/i18n/messages/ar.json
@@ -247,7 +247,13 @@
       "previewDatasetRows": "صفوف",
       "previewDatasetColumns": "أعمدة",
       "previewDatasetSize": "الحجم",
-      "previewJsonFormat": "JSON منسق"
+      "previewJsonFormat": "JSON منسق",
+      "githubPreview": {
+        "title": "معاينة المستودع",
+        "topics": "المواضيع",
+        "recentCommits": "أحدث الالتزامات",
+        "viewCommit": "عرض الالتزام"
+      }
     }
   },
   "footer": {

--- a/src/shared/ui/i18n/messages/en.json
+++ b/src/shared/ui/i18n/messages/en.json
@@ -247,7 +247,13 @@
       "previewDatasetRows": "Rows",
       "previewDatasetColumns": "Columns",
       "previewDatasetSize": "Size",
-      "previewJsonFormat": "Formatted JSON"
+      "previewJsonFormat": "Formatted JSON",
+      "githubPreview": {
+        "title": "Repository preview",
+        "topics": "Topics",
+        "recentCommits": "Recent commits",
+        "viewCommit": "View commit"
+      }
     }
   },
   "footer": {

--- a/src/types/resource.ts
+++ b/src/types/resource.ts
@@ -63,6 +63,19 @@ export interface GithubStats {
   last_commit: string;  // ISO 8601
 }
 
+export interface GithubCommit {
+  sha: string;
+  message: string;
+  author: string;
+  date: string;
+  url: string;
+}
+
+export interface GithubRepoPreview {
+  topics: string[];
+  commits: GithubCommit[];
+}
+
 export interface Consumer {
   name: string;
   logo_url?: string;


### PR DESCRIPTION
Closes #189

## Summary
Adds a real GitHub repo preview on resource detail pages: recent commits and topics for resources with a valid `https://github.com/owner/repo` URL.

The preview is fetched server-side in this Next.js app (not the CMS/backend), cached with `next: { revalidate: 300 }`, and uses a server-only `GITHUB_API_TOKEN`. `GithubStatsCard` is unchanged; a new sibling component renders below it. Resources without a GitHub URL, or with a non-github.com URL, show no preview.

## Approach
- Parse `github_url` and fetch commits (`per_page=5`) + topics from the GitHub API
- Native `fetch` only (edge runtime)
- On missing token or API error, return `null` so the page never crashes
- All UI copy goes through i18n (`en.json` / `ar.json`), RTL-safe

## Screenshots
<img width="807" height="774" alt="image" src="https://github.com/user-attachments/assets/bffb2eee-0a12-4ba6-a470-6d1e9608bc05" />

## Test plan
- [x] `npm run test:run` — URL parsing and fetch error handling
- [x] `npm run build`
- [ ] Resource with a valid `github_url` + `GITHUB_API_TOKEN` shows commits (and topics if the repo has them)
- [ ] Resource without `github_url` shows no preview
- [ ] Missing token fails silently; page still loads

## Notes
`GITHUB_API_TOKEN` (read-only GitHub PAT) is required in production. Do not expose it as `NEXT_PUBLIC_*`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added GitHub repository previews to resource detail pages.
  - Displays repository topics and recent commits with localized labels and date formatting.
  - Supports direct links to view individual commits.
  - Added English and Arabic translations.

- **Bug Fixes**
  - Invalid, unavailable, or unsupported repository links now gracefully omit the preview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->