### PR TITLE
fix(developer): update developer top bar offset to clear global header

### DIFF
--- a/src/app/developer/layout.tsx
+++ b/src/app/developer/layout.tsx
@@ -50,7 +50,7 @@ export default function DeveloperLayout({
 
       <div className="flex-grow pt-32">
         {/* Top bar */}
-        <div className="bg-[var(--bg-card)] border-b border-[var(--border-color)] px-6 py-4 flex items-center justify-between sticky top-32 z-20">
+        <div className="bg-[var(--bg-card)] border-b border-[var(--border-color)] px-6 py-4 flex items-center justify-between sticky lg:top-32 z-20">
           <div className="flex items-center gap-3">
             {/* Mobile hamburger toggle */}
             <button


### PR DESCRIPTION
Fixes the developer top bar overlap with the global site header by updating the offset from `top-0` to `top-32` in `src/app/developer/layout.tsx`.

## Changes
- Updated sticky position in `src/app/developer/layout.tsx` to `top-
<img width="308" height="647" alt="image" src="https://github.com/user-attachments/assets/3b87c281-06f0-434b-838a-0c5324d12410" />
<img width="1897" height="918" alt="image" src="https://github.com/user-attachments/assets/bd36b6dc-3b8e-4258-a377-2cac8f807547" />
32`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the developer area’s top bar behavior by keeping it visible while scrolling on large screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->