### PR TITLE
docs: link GitHub Discussions and CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on Keep a Changelog.
+
+[Unreleased]
+Added
+Public GitHub Discussions link and this CHANGELOG, linked from README (#168)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
-Changelog
+# Changelog
 
 All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog.
 
-[Unreleased]
-Added
+## [Unreleased]
+
+### Added
 Public GitHub Discussions link and this CHANGELOG, linked from README (#168)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Every merged contribution gets a shoutout on the [Contributors page](https://rat
 
 <img src="./docs/images/contributors-page.png" alt="RATQ Contributors page" width="600" />
 
+## Community
+
+Have questions or want to discuss design decisions? Use [GitHub Discussions](https://github.com/Itqan-community/RATQ/discussions).
+
+See [CHANGELOG.md](https://github.com/Itqan-community/RATQ/blob/main/CHANGELOG.md) for a history of notable changes.
+
 ## License
 
 [MIT](./LICENSE)


### PR DESCRIPTION
I have Create CHANGELOG.md File and put new section in README.md contains GitHub Discussions and CHANGELOG.md links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a changelog with an Unreleased section for tracking notable changes.
  - Added a Community section to the README with links for questions, design discussions, and release history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->