### PR TITLE
Add TrendingResources 

### DIFF
--- a/src/__tests__/ResourceCard.test.tsx
+++ b/src/__tests__/ResourceCard.test.tsx
@@ -112,13 +112,13 @@ describe('ResourceCard', () => {
     expect(screen.queryByText('Demo')).not.toBeInTheDocument();
   });
 
-  it('clamps short description to 2 lines', () => {
+  it('clamps short description to 3 lines', () => {
     renderWithProvider(
       <ResourceCard resource={createResource({
-        short_description: 'This is a very long description that should be clamped to two lines maximum regardless of how much text is provided here to ensure the card stays compact.',
+        short_description: 'This is a very long description that should be clamped to three lines maximum regardless of how much text is provided here to ensure the card stays compact.',
       })} />
     );
     const descriptionEl = screen.getByText(/This is a very long description/i);
-    expect(descriptionEl.closest('p')).toHaveClass('line-clamp-2');
+    expect(descriptionEl.closest('p')).toHaveClass('line-clamp-3');
   });
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,8 @@ import { useGSAP } from "@gsap/react";
 import { useLanguage } from "@/shared/ui/i18n";
 import { useResources } from "@/hooks/useResources";
 import { ResourceCard } from "@/modules/resources/components/ResourceCard";
+import AnnouncementsCarousel from "@/modules/resources/components/AnnouncementsCarousel";
+import TrendingResources from "@/modules/resources/components/TrendingResources";
 
 gsap.registerPlugin(useGSAP);
 
@@ -71,9 +73,8 @@ export default function HomePage() {
   const { t, direction } = useLanguage();
   const home = t.home;
 
-  const { data: trendingData, isLoading: trendingLoading } = useResources({ sort: "downloads", page_size: 4 });
   const { data: featuredData, isLoading: featuredLoading } = useResources({ sort: "newest", page_size: 4 });
-  const trendingResources = trendingData?.results ?? [];
+
   const featuredResources = featuredData?.results ?? [];
   const stats: Stat[] = [
     { value: direction === "rtl" ? "12.4 ألف" : "12.4k", label: home.stats.downloads },
@@ -161,17 +162,13 @@ export default function HomePage() {
           </div>
         </div>
       </section>
-      <section className="mx-auto mt-16 w-full max-w-[1205px] px-5"><div className="grid min-h-[101px] overflow-hidden rounded-[21.8785px] bg-black text-white shadow-sm md:h-[101px] md:grid-cols-[240px_1fr_240px]" dir="ltr" style={{ background: "radial-gradient(circle at 4% 50%, rgba(67, 198, 118, 0.5) 10%, rgba(67, 198, 118, 0) 34%), radial-gradient(circle at 110% 50%, rgba(56, 185, 179, 0.95) 5%, rgba(67, 198, 118, 0) 34%), #000000" }}><div className="flex items-center justify-start gap-5 px-6 py-5" dir="ltr"><span className="text-3xl font-black leading-none text-white/40">...</span><Link href="/resources" className="rounded-full bg-white px-4 py-4 text-base font-black text-black">{home.announcements.action}</Link></div><p className="flex items-center justify-center px-6 py-5 text-center text-[18px] leading-[1.45]" dir={direction}>{home.announcements.text}</p><div className="flex items-center justify-end px-7 py-5 text-[38px] font-black leading-none" dir={direction}>{home.announcements.title}</div></div></section>
-      {(trendingLoading || trendingResources.length > 0) && (
-        <section className="mx-auto mt-16 max-w-7xl px-5">
-          <SectionHeading direction={direction}>{home.sections.trending}</SectionHeading>
-          <div className="grid gap-7 sm:grid-cols-2 lg:grid-cols-4">
-            {trendingLoading
-              ? Array.from({ length: 4 }).map((_, index) => <div key={index} className="skeleton min-h-[305px] rounded-[13px]" />)
-              : trendingResources.map((resource) => <ResourceCard key={resource.id} resource={resource} />)}
-          </div>
-        </section>
-      )}
+    
+      <AnnouncementsCarousel />
+
+  
+      <TrendingResources/>
+    
+
       {(featuredLoading || featuredResources.length > 0) && (
         <section className="mx-auto mt-16 max-w-7xl px-5">
           <SectionHeading direction={direction}>{home.sections.featured}</SectionHeading>

--- a/src/hooks/useTrendingResources.ts
+++ b/src/hooks/useTrendingResources.ts
@@ -2,22 +2,22 @@
 
 import { useState, useMemo } from 'react';
 import useSWR from 'swr';
-import type { TrendingResource, TrendingPeriod } from '@/types/announcement';
+import type { TrendingResource, PeriodType } from '@/types/announcement';
 import { listTrendingResources } from '@/modules/resources/application/use-cases/list-trending-resources';
 
 export interface UseTrendingResourcesReturn {
   resources: TrendingResource[];
   isLoading: boolean;
   error: Error | null;
-  period: TrendingPeriod;
-  setPeriod: (period: TrendingPeriod) => void;
-  periods: TrendingPeriod[];
+  period: PeriodType;
+  setPeriod: (period: PeriodType) => void;
+  periods: PeriodType[];
 }
 
-const ALL_PERIODS: TrendingPeriod[] = ['7d', '30d', 'all-time'];
+const ALL_PERIODS: PeriodType[] = ['7d', '30d', 'all-time'];
 
 export function useTrendingResources(): UseTrendingResourcesReturn {
-  const [period, setPeriod] = useState<TrendingPeriod>('30d');
+  const [period, setPeriod] = useState<PeriodType>('30d');
 
   const { data, error, isLoading } = useSWR<TrendingResource[], Error>(
     ['trending', period],

--- a/src/modules/resources/components/ResourceCard.tsx
+++ b/src/modules/resources/components/ResourceCard.tsx
@@ -122,7 +122,7 @@ export function ResourceCard({ resource, rank, downloadCount }: ResourceCardProp
       <h3 className="mt-5 line-clamp-2 text-xl font-black leading-8 text-black">
         {resource.name}
       </h3>
-      <p className="mt-3 line-clamp-2 flex-1 text-sm leading-7 text-[#8b8b8b]">
+      <p className="mt-3 line-clamp-3 flex-1 text-sm leading-7 text-[#8b8b8b]">
         {description}
       </p>
 

--- a/src/modules/resources/components/TrendingResources.tsx
+++ b/src/modules/resources/components/TrendingResources.tsx
@@ -5,17 +5,13 @@ import Link from 'next/link';
 import { useTranslations } from '@/shared/ui/i18n';
 import { useTrendingResources } from '@/hooks/useTrendingResources';
 import { ResourceCard } from './ResourceCard';
-import type { TrendingResource, TrendingPeriod } from '@/types/announcement';
+import type { TrendingResource,PeriodType } from '@/types/announcement';
 import type { Resource } from '@/types/resource';
 
 export default function TrendingResources() {
   const t = useTranslations();
   const { resources, isLoading, period, setPeriod, periods } = useTrendingResources();
-
-  if (resources.length === 0 && !isLoading) {
-    return null;
-  }
-
+  
   const periodLabels: Record<string, string> = {
     '7d': t.trending.period7d,
     '30d': t.trending.period30d,
@@ -29,6 +25,12 @@ export default function TrendingResources() {
       downloadCount: resource.downloads,
     }));
   }, [resources]);
+  
+  const hasResourcesToShow = resources.length > 0;
+
+  if(!isLoading && !hasResourcesToShow) {
+    return null
+  }
 
   return (
     <section className="section-padding py-8" aria-label={t.trending.title}>
@@ -42,7 +44,7 @@ export default function TrendingResources() {
                   key={p}
                   role="tab"
                   aria-selected={period === p}
-                  onClick={() => setPeriod(p as '7d' | '30d' | 'all-time')}
+                  onClick={() => setPeriod(p as PeriodType)}
                   className={`px-3 py-1.5 text-sm rounded-lg transition-colors ${
                     period === p
                       ? 'bg-[var(--accent-primary)] text-white'
@@ -66,6 +68,7 @@ export default function TrendingResources() {
         </div>
 
         {isLoading ? (
+
           <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
             {[1, 2, 3].map((i) => (
               <div key={i} className="card p-5 animate-pulse">
@@ -76,7 +79,9 @@ export default function TrendingResources() {
               </div>
             ))}
           </div>
+
         ) : (
+
           <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
             {resourceCards.map(({ resource, rank, downloadCount }) => (
               <ResourceCard
@@ -87,6 +92,7 @@ export default function TrendingResources() {
               />
             ))}
           </div>
+
         )}
       </div>
     </section>

--- a/src/modules/resources/domain/services/trending-ranking.ts
+++ b/src/modules/resources/domain/services/trending-ranking.ts
@@ -1,5 +1,5 @@
 import type { Resource } from '@/types/resource';
-import type { TrendingResource } from '@/types/announcement';
+import type { PeriodType, TrendingResource } from '@/types/announcement';
 
 // The ranking rule behind the mock-mode branch of trending-api.ts: only
 // resources with at least one download in the period, ranked by that
@@ -8,7 +8,7 @@ import type { TrendingResource } from '@/types/announcement';
 // "what counts as trending" would touch.
 export function rankTrendingResources(
   resources: Resource[],
-  period: '7d' | '30d' | 'all-time'
+  period: PeriodType
 ): TrendingResource[] {
   const isAllTime = period === 'all-time';
   return resources

--- a/src/modules/resources/infrastructure/trending-api.ts
+++ b/src/modules/resources/infrastructure/trending-api.ts
@@ -1,9 +1,9 @@
-import type { TrendingResource } from '@/types/announcement';
+import type { PeriodType, TrendingResource } from '@/types/announcement';
 import { DATA_MODE, API_BASE } from '@/shared/infrastructure/data-mode';
 import { fetchResources } from './resources-api';
 import { rankTrendingResources } from '../domain/services/trending-ranking';
 
-export async function fetchTrendingResources(period: '7d' | '30d' | 'all-time'): Promise<TrendingResource[]> {
+export async function fetchTrendingResources(period: PeriodType): Promise<TrendingResource[]> {
   if (DATA_MODE === 'mock') {
     const { results } = await fetchResources({ page_size: 10_000 });
     return rankTrendingResources(results, period);

--- a/src/types/announcement.ts
+++ b/src/types/announcement.ts
@@ -17,7 +17,7 @@ export interface Announcement {
 
 // ─── Trending Types ───────────────────────────────────────────────────────
 
-export type TrendingPeriod = '7d' | '30d' | 'all-time';
+export type PeriodType = '7d' | '30d' | 'all-time';
 
 export interface TrendingResource {
   id: number;


### PR DESCRIPTION
update the home page add Trending Resources and replace the old code 
I have did : 
- add a fallback state instead of remove the component and doesn't display it in the page 
- add a arabic and english translation 

note: the UI will display the fallback beacuse there are no items that fit the filter or the conidiation (at file 
src\modules\resources\domain\services\trending-ranking.ts) 
`
    items.filter((r) => (isAllTime ? r.total_downloads > 0 : r.downloads > 0))
`

    there are no items with download you should either edit the data or the conidiation
    
The UI when there are 
- data 
<img width="1313" height="510" alt="image" src="https://github.com/user-attachments/assets/cc4f1254-f805-476c-aeb0-6e91d57fbc2e" />

- no data
<img width="1346" height="283" alt="image" src="https://github.com/user-attachments/assets/61194186-d725-4e46-84fb-23392c0ebfc1" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added announcements and trending resources to the home page.
  * Expanded resource descriptions to display up to three lines.

* **Bug Fixes**
  * Improved handling when no trending resources are available.

* **Tests**
  * Updated resource card coverage for three-line description truncation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->