### PR TITLE
fix(auth): redirect authenticated users from login to dashboard

### DIFF
--- a/src/__tests__/LoginPage.test.tsx
+++ b/src/__tests__/LoginPage.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import LoginPage from '@/app/login/page';
+import { useAuth } from '@/hooks/useAuth';
+import { useRouter } from 'next/navigation';
+
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, className }: any) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('@/modules/auth/components/LoginForm', () => ({
+  LoginForm: () => <div data-testid="login-form">LoginForm Component</div>,
+}));
+
+vi.mock('@/shared/ui/i18n', () => ({
+  useLanguage: () => ({
+    t: {
+      auth: {
+        loginTitle: 'تسجيل الدخول',
+        loginSubtitle: 'مرحباً بك في منصتنا',
+        loginBenefit1: 'ميزة 1',
+        loginBenefit2: 'ميزة 2',
+        loginBenefit3: 'ميزة 3',
+        loginPanelTitle: 'عنوان اللوحة',
+        loginNote: 'ملاحظة عامة',
+        noAccount: 'ليس لديك حساب؟',
+        registerNow: 'سجل الآن',
+        developerSpace: 'مساحة المطورين',
+      },
+    },
+    direction: 'rtl',
+  }),
+}));
+
+describe('LoginPage', () => {
+  const pushMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useRouter).mockReturnValue({ push: pushMock } as any);
+  });
+
+  it('redirects an active logged-in user to /dashboard', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: { id: 1, email: 'dev@example.com', display_name: 'Test Dev', role: 'developer' } as any,
+      loading: false,
+      error: null,
+      login: vi.fn(),
+      loginWithToken: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+    });
+
+    render(<LoginPage />);
+
+    expect(pushMock).toHaveBeenCalledWith('/dashboard');
+    expect(screen.queryByTestId('login-form')).not.toBeInTheDocument();
+  });
+
+  it('renders login form when no active user session exists', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: null,
+      loading: false,
+      error: null,
+      login: vi.fn(),
+      loginWithToken: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+    });
+
+    render(<LoginPage />);
+
+    expect(screen.getByTestId('login-form')).toBeInTheDocument();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it('shows loading indicator and prevents form flash while auth state is resolving', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: null,
+      loading: true,
+      error: null,
+      login: vi.fn(),
+      loginWithToken: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+    });
+
+    render(<LoginPage />);
+
+    expect(screen.queryByTestId('login-form')).not.toBeInTheDocument();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,14 +1,33 @@
 'use client';
 
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import Link from 'next/link';
 import { LoginForm } from '@/modules/auth/components/LoginForm';
 import { useLanguage } from '@/shared/ui/i18n';
+import { useAuth } from '@/hooks/useAuth';
 
 function CheckIcon() { return <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="m5 12 4 4L19 6" /></svg>; }
 
 export default function LoginPage() {
   const { t, direction } = useLanguage();
+  const { user, loading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!loading && user) {
+      router.push('/dashboard');
+    }
+  }, [user, loading, router]);
+
+  if (loading || user) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-solid border-[#171717] border-t-transparent" />
+      </div>
+    );
+  }
   const copy = t.auth;
   const highlights = [copy.loginBenefit1, copy.loginBenefit2, copy.loginBenefit3];
   return (


### PR DESCRIPTION
Closes 239

**Summary of Changes**
- Checked the authentication state inside `src/app/login/page.tsx` using `useAuth`.
- Added redirection to `/dashboard` for already authenticated users (`user !== null`) once loading completes.
- Handled loading state to prevent flash of the login form before redirection.
- Added unit tests in `src/__tests__/LoginPage.test.tsx` covering both authenticated (redirection) and unauthenticated states.

**Testing**
- Ran `npm run test:run` and verified that all tests pass, including the new `LoginPage` test suite.
- Ran `npm run lint` with no new lint errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Authenticated users are automatically redirected to the dashboard from the login page.
  - A loading indicator appears while authentication status is being determined.
  - Unauthenticated visitors continue to see the login form.

- **Bug Fixes**
  - Prevented authenticated users from accessing the login form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->