### PR TITLE
feat:  Trending Resources (Home page) 

### DIFF
--- a/src/__tests__/ResourceCard.test.tsx
+++ b/src/__tests__/ResourceCard.test.tsx
@@ -112,13 +112,13 @@ describe('ResourceCard', () => {
     expect(screen.queryByText('Demo')).not.toBeInTheDocument();
   });
 
-  it('clamps short description to 2 lines', () => {
+  it('clamps short description to 3 lines', () => {
     renderWithProvider(
       <ResourceCard resource={createResource({
-        short_description: 'This is a very long description that should be clamped to two lines maximum regardless of how much text is provided here to ensure the card stays compact.',
+        short_description: 'This is a very long description that should be clamped to three lines maximum regardless of how much text is provided here to ensure the card stays compact.',
       })} />
     );
     const descriptionEl = screen.getByText(/This is a very long description/i);
-    expect(descriptionEl.closest('p')).toHaveClass('line-clamp-2');
+    expect(descriptionEl.closest('p')).toHaveClass('line-clamp-3');
   });
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import { useLanguage } from "@/shared/ui/i18n";
 import { useResources } from "@/hooks/useResources";
 import { ResourceCard } from "@/modules/resources/components/ResourceCard";
 import AnnouncementsCarousel from "@/modules/resources/components/AnnouncementsCarousel";
+import TrendingResources from "@/modules/resources/components/TrendingResources";
 
 gsap.registerPlugin(useGSAP);
 
@@ -72,9 +73,7 @@ export default function HomePage() {
   const { t, direction } = useLanguage();
   const home = t.home;
 
-  const { data: trendingData, isLoading: trendingLoading } = useResources({ sort: "downloads", page_size: 4 });
   const { data: featuredData, isLoading: featuredLoading } = useResources({ sort: "newest", page_size: 4 });
-  const trendingResources = trendingData?.results ?? [];
   const featuredResources = featuredData?.results ?? [];
   const stats: Stat[] = [
     { value: direction === "rtl" ? "12.4 ألف" : "12.4k", label: home.stats.downloads },
@@ -165,16 +164,8 @@ export default function HomePage() {
     
       <AnnouncementsCarousel />
 
-      {(trendingLoading || trendingResources.length > 0) && (
-        <section className="mx-auto mt-16 max-w-7xl px-5">
-          <SectionHeading direction={direction}>{home.sections.trending}</SectionHeading>
-          <div className="grid gap-7 sm:grid-cols-2 lg:grid-cols-4">
-            {trendingLoading
-              ? Array.from({ length: 4 }).map((_, index) => <div key={index} className="skeleton min-h-[305px] rounded-[13px]" />)
-              : trendingResources.map((resource) => <ResourceCard key={resource.id} resource={resource} />)}
-          </div>
-        </section>
-      )}
+      <TrendingResources />
+
       {(featuredLoading || featuredResources.length > 0) && (
         <section className="mx-auto mt-16 max-w-7xl px-5">
           <SectionHeading direction={direction}>{home.sections.featured}</SectionHeading>

--- a/src/modules/resources/components/ResourceCard.tsx
+++ b/src/modules/resources/components/ResourceCard.tsx
@@ -122,7 +122,7 @@ export function ResourceCard({ resource, rank, downloadCount }: ResourceCardProp
       <h3 className="mt-5 line-clamp-2 text-xl font-black leading-8 text-black">
         {resource.name}
       </h3>
-      <p className="mt-3 line-clamp-2 flex-1 text-sm leading-7 text-[#8b8b8b]">
+      <p className="mt-3 line-clamp-3 flex-1 text-sm leading-7 text-[#8b8b8b]">
         {description}
       </p>
 

--- a/src/modules/resources/components/TrendingResources.tsx
+++ b/src/modules/resources/components/TrendingResources.tsx
@@ -12,9 +12,7 @@ export default function TrendingResources() {
   const t = useTranslations();
   const { resources, isLoading, period, setPeriod, periods } = useTrendingResources();
 
-  if (resources.length === 0 && !isLoading) {
-    return null;
-  }
+
 
   const periodLabels: Record<string, string> = {
     '7d': t.trending.period7d,
@@ -30,6 +28,11 @@ export default function TrendingResources() {
     }));
   }, [resources]);
 
+  const hasResourcesToShow = resourceCards.length > 0;
+    if (!hasResourcesToShow && !isLoading) {
+    return null;
+  }
+
   return (
     <section className="section-padding py-8" aria-label={t.trending.title}>
       <div className="max-w-6xl mx-auto">
@@ -42,7 +45,7 @@ export default function TrendingResources() {
                   key={p}
                   role="tab"
                   aria-selected={period === p}
-                  onClick={() => setPeriod(p as '7d' | '30d' | 'all-time')}
+                  onClick={() => setPeriod(p as TrendingPeriod)}
                   className={`px-3 py-1.5 text-sm rounded-lg transition-colors ${
                     period === p
                       ? 'bg-[var(--accent-primary)] text-white'


### PR DESCRIPTION
update the home page add Trending Resources and replace the old code 
I have did : 
- add a fallback state instead of remove the component and doesn't display it in the page 
- add a arabic and english translation 

note: the UI will display the fallback beacuse there are no items that fit the filter or the conidiation (at file 
src\modules\resources\domain\services\trending-ranking.ts) 
`
    items.filter((r) => (isAllTime ? r.total_downloads > 0 : r.downloads > 0))
`

    there are no items with download you should either edit the data or the conidiation
    
The UI when there are 
- data 
<img width="1313" height="510" alt="image" src="https://github.com/user-attachments/assets/cc4f1254-f805-476c-aeb0-6e91d57fbc2e" />

- no data
<img width="1346" height="283" alt="image" src="https://github.com/user-attachments/assets/61194186-d725-4e46-84fb-23392c0ebfc1" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable trending resources section to the home page.
  * Trending resources now display an appropriate empty state when no results are available.

* **Improvements**
  * Resource descriptions can now display up to three lines, improving readability.
  * Trending resource period selection has been streamlined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->