### PR TITLE
feat(announcements): add Payload-backed announcements

### DIFF
--- a/payload-backend/src/collections/Announcements.test.ts
+++ b/payload-backend/src/collections/Announcements.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+
+import { Announcements } from './Announcements'
+
+interface ReqUser {
+  id: number
+  role?: string
+}
+
+interface AccessArgs {
+  req: { user: ReqUser | null }
+}
+
+function makeReq(user: ReqUser | null): AccessArgs {
+  return { req: { user } }
+}
+
+describe('Announcements read access', () => {
+  const readAccess = Announcements.access!.read as (args: AccessArgs) => unknown
+
+  it('public unauthenticated readers only see active, non-expired announcements', () => {
+    const result = readAccess(makeReq(null)) as { and: Record<string, unknown>[] }
+    const activeFilter = result.and.find((c) => 'is_active' in c)
+    expect(activeFilter).toEqual({ is_active: { equals: true } })
+  })
+
+  it('filters out expired announcements (only future expires_at allowed)', () => {
+    const result = readAccess(makeReq(null)) as { and: Record<string, unknown>[] }
+    const expiryFilter = result.and.find((c) => 'or' in c) as { or: Record<string, unknown>[] }
+    expect(expiryFilter.or).toContainEqual({
+      expires_at: { greater_than: expect.any(String) },
+    })
+  })
+
+  it('allows announcements with no expires_at (never expiring)', () => {
+    const result = readAccess(makeReq(null)) as { and: Record<string, unknown>[] }
+    const expiryFilter = result.and.find((c) => 'or' in c) as { or: Record<string, unknown>[] }
+    expect(expiryFilter.or).toContainEqual({ expires_at: { exists: false } })
+  })
+
+  it('admin sees any announcement regardless of active/expiry state', () => {
+    const result = readAccess(makeReq({ id: 99, role: 'admin' }))
+    expect(result).toBe(true)
+  })
+
+  it('non-admin authenticated readers are scoped like public readers', () => {
+    const result = readAccess(makeReq({ id: 1, role: 'developer' }))
+    expect(result).toEqual(expect.objectContaining({ and: expect.any(Array) }))
+  })
+})
+
+describe('Announcements create access', () => {
+  const createAccess = Announcements.access!.create as (args: AccessArgs) => unknown
+
+  it('denies unauthenticated callers', () => {
+    expect(createAccess(makeReq(null))).toBe(false)
+  })
+
+  it('denies non-admin authenticated users', () => {
+    expect(createAccess(makeReq({ id: 1, role: 'developer' }))).toBe(false)
+    expect(createAccess(makeReq({ id: 2, role: 'publisher' }))).toBe(false)
+  })
+
+  it('allows an admin', () => {
+    expect(createAccess(makeReq({ id: 99, role: 'admin' }))).toBe(true)
+  })
+})
+
+describe('Announcements update access', () => {
+  const updateAccess = Announcements.access!.update as (args: AccessArgs) => unknown
+
+  it('denies unauthenticated callers', () => {
+    expect(updateAccess(makeReq(null))).toBe(false)
+  })
+
+  it('denies non-admin authenticated users', () => {
+    expect(updateAccess(makeReq({ id: 1, role: 'developer' }))).toBe(false)
+    expect(updateAccess(makeReq({ id: 2, role: 'publisher' }))).toBe(false)
+  })
+
+  it('allows an admin', () => {
+    expect(updateAccess(makeReq({ id: 99, role: 'admin' }))).toBe(true)
+  })
+})
+
+describe('Announcements delete access', () => {
+  const deleteAccess = Announcements.access!.delete as (args: AccessArgs) => unknown
+
+  it('denies unauthenticated callers', () => {
+    expect(deleteAccess(makeReq(null))).toBe(false)
+  })
+
+  it('denies non-admin authenticated users', () => {
+    expect(deleteAccess(makeReq({ id: 1, role: 'developer' }))).toBe(false)
+    expect(deleteAccess(makeReq({ id: 2, role: 'publisher' }))).toBe(false)
+  })
+
+  it('allows an admin', () => {
+    expect(deleteAccess(makeReq({ id: 99, role: 'admin' }))).toBe(true)
+  })
+})

--- a/payload-backend/src/collections/Announcements.ts
+++ b/payload-backend/src/collections/Announcements.ts
@@ -1,0 +1,105 @@
+import type { Access, CollectionConfig, Where } from 'payload'
+
+const isAdmin: Access = ({ req }) => req.user?.role === 'admin'
+
+// The homepage carousel fetches announcements unauthenticated, so public
+// readers see only announcements that are both active and not yet expired
+// (or never expiring). Admin sees everything, including drafts of upcoming
+// announcements.
+const canReadAnnouncement: Access = ({ req }) => {
+  if (req.user?.role === 'admin') return true
+
+  const now = new Date().toISOString()
+
+  const where: Where = {
+    and: [
+      {
+        is_active: {
+          equals: true,
+        },
+      },
+      {
+        or: [
+          {
+            expires_at: {
+              exists: false,
+            },
+          },
+          {
+            expires_at: {
+              greater_than: now,
+            },
+          },
+        ],
+      },
+    ],
+  }
+
+  return where
+}
+
+// Mirrors src/types/announcement.ts AnnouncementType.
+const ANNOUNCEMENT_TYPES = [
+  'release',
+  'new_resource',
+  'maintenance',
+  'breaking_change',
+] as const
+
+export const Announcements: CollectionConfig = {
+  slug: 'announcements',
+
+  access: {
+    read: canReadAnnouncement,
+    create: isAdmin,
+    update: isAdmin,
+    delete: isAdmin,
+  },
+
+  admin: {
+    useAsTitle: 'title',
+  },
+
+  fields: [
+    {
+      name: 'type',
+      type: 'select',
+      required: true,
+      options: ANNOUNCEMENT_TYPES.map((value) => ({ label: value, value })),
+    },
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'description',
+      type: 'textarea',
+      required: true,
+    },
+    {
+      name: 'resource_id',
+      type: 'relationship',
+      relationTo: 'resources',
+      index: true,
+    },
+    {
+      name: 'cta_url',
+      type: 'text',
+    },
+    {
+      name: 'cta_label',
+      type: 'text',
+    },
+    {
+      name: 'expires_at',
+      type: 'date',
+    },
+    {
+      name: 'is_active',
+      type: 'checkbox',
+      required: true,
+      defaultValue: true,
+    },
+  ],
+}

--- a/payload-backend/src/payload-types.ts
+++ b/payload-backend/src/payload-types.ts
@@ -75,6 +75,7 @@ export interface Config {
     'access-requests': AccessRequest;
     'api-keys': ApiKey;
     notifications: Notification;
+    announcements: Announcement;
     'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -90,6 +91,7 @@ export interface Config {
     'access-requests': AccessRequestsSelect<false> | AccessRequestsSelect<true>;
     'api-keys': ApiKeysSelect<false> | ApiKeysSelect<true>;
     notifications: NotificationsSelect<false> | NotificationsSelect<true>;
+    announcements: AnnouncementsSelect<false> | AnnouncementsSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -296,6 +298,23 @@ export interface Notification {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "announcements".
+ */
+export interface Announcement {
+  id: number;
+  type: 'release' | 'new_resource' | 'maintenance' | 'breaking_change';
+  title: string;
+  description: string;
+  resource_id?: (number | null) | Resource;
+  cta_url?: string | null;
+  cta_label?: string | null;
+  expires_at?: string | null;
+  is_active: boolean;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
 export interface PayloadKv {
@@ -349,6 +368,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'notifications';
         value: number | Notification;
+      } | null)
+    | ({
+        relationTo: 'announcements';
+        value: number | Announcement;
       } | null);
   globalSlug?: string | null;
   user: {
@@ -521,6 +544,22 @@ export interface NotificationsSelect<T extends boolean = true> {
   related_report?: T;
   related_comment?: T;
   read?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "announcements_select".
+ */
+export interface AnnouncementsSelect<T extends boolean = true> {
+  type?: T;
+  title?: T;
+  description?: T;
+  resource_id?: T;
+  cta_url?: T;
+  cta_label?: T;
+  expires_at?: T;
+  is_active?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/payload-backend/src/payload.config.ts
+++ b/payload-backend/src/payload.config.ts
@@ -6,6 +6,7 @@ import sharp from 'sharp'
 import { fileURLToPath } from 'url'
 
 import { AccessRequests } from './collections/AccessRequests'
+import { Announcements } from './collections/Announcements'
 import { APIKeys } from './collections/APIKeys'
 import { Notifications } from './collections/Notifications'
 import { Comments } from './collections/Comments'
@@ -41,7 +42,7 @@ export default buildConfig({
       beforeLogin: ['/admin/BeforeLogin#BeforeLogin'],
     },
   },
-  collections: [Users, Media, Resources, Comments, Reports, AccessRequests, APIKeys, Notifications],
+  collections: [Users, Media, Resources, Comments, Reports, AccessRequests, APIKeys, Notifications, Announcements],
   editor: lexicalEditor(),
   secret: process.env.PAYLOAD_SECRET || '',
   typescript: {

--- a/src/__tests__/announcements-api.test.ts
+++ b/src/__tests__/announcements-api.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockAnnouncements } from '@/modules/resources/infrastructure/mock-data';
+import type { Announcement } from '@/types/announcement';
+
+type FetchAnnouncements = typeof import('@/modules/resources/infrastructure/announcements-api').fetchAnnouncements;
+
+const pageUrl = (page: number) =>
+  `https://api.test/api/announcements/?depth=1&limit=100&sort=-createdAt&page=${page}`;
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return { ok, json: async () => body } as Response;
+}
+
+function doc(id: number, title: string, overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id,
+    type: 'release',
+    title,
+    description: `description ${id}`,
+    createdAt: '2026-08-20T00:00:00Z',
+    is_active: true,
+    ...overrides,
+  };
+}
+
+describe('fetchAnnouncements (live mode)', () => {
+  let fetchAnnouncements: FetchAnnouncements;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.stubEnv('NEXT_PUBLIC_DATA_MODE', 'live');
+    vi.stubEnv('NEXT_PUBLIC_API_URL', 'https://api.test');
+    vi.stubGlobal('fetch', vi.fn());
+    fetchAnnouncements = (await import('@/modules/resources/infrastructure/announcements-api'))
+      .fetchAnnouncements;
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('fetches a single page and maps docs to the frontend contract', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      jsonResponse({ docs: [doc(1, 'First')], hasNextPage: false, page: 1 }),
+    );
+
+    const result = await fetchAnnouncements();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(pageUrl(1));
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: '1',
+        type: 'release',
+        title: 'First',
+        description: 'description 1',
+        created_at: '2026-08-20T00:00:00Z',
+        is_active: true,
+      }),
+    ]);
+  });
+
+  it('pages through until hasNextPage is false and preserves order', async () => {
+    vi.mocked(fetch).mockImplementation(async (input) => {
+      const url = String(input);
+      if (url === pageUrl(1)) {
+        return jsonResponse({
+          docs: [doc(1, 'First'), doc(2, 'Second')],
+          hasNextPage: true,
+          nextPage: 2,
+          page: 1,
+        });
+      }
+      return jsonResponse({ docs: [doc(3, 'Third')], hasNextPage: false, page: 2 });
+    });
+
+    const result = await fetchAnnouncements();
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(fetch).toHaveBeenCalledWith(pageUrl(1));
+    expect(fetch).toHaveBeenCalledWith(pageUrl(2));
+    expect(result.map((a) => a.title)).toEqual(['First', 'Second', 'Third']);
+  });
+
+  it('stops when hasNextPage is true but nextPage is missing (malformed metadata)', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      jsonResponse({ docs: [doc(1, 'First')], hasNextPage: true, page: 1 }),
+    );
+
+    const result = await fetchAnnouncements();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(result).toHaveLength(1);
+  });
+
+  it('stops when nextPage does not move forward (no infinite loop)', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      jsonResponse({ docs: [doc(1, 'First')], hasNextPage: true, nextPage: 1, page: 1 }),
+    );
+
+    const result = await fetchAnnouncements();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(result).toHaveLength(1);
+  });
+
+  it('stops at totalPages even if nextPage claims more (no infinite loop)', async () => {
+    vi.mocked(fetch).mockImplementation(async (input) => {
+      const url = String(input);
+      if (url === pageUrl(1)) {
+        return jsonResponse({
+          docs: [doc(1, 'First')],
+          hasNextPage: true,
+          nextPage: 2,
+          page: 1,
+          totalPages: 1,
+        });
+      }
+      return jsonResponse({
+        docs: [doc(2, 'Second')],
+        hasNextPage: true,
+        nextPage: 3,
+        page: 2,
+        totalPages: 2,
+      });
+    });
+
+    const result = await fetchAnnouncements();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(result).toHaveLength(1);
+  });
+
+  it('rejects when a page is not ok', async () => {
+    vi.mocked(fetch).mockResolvedValue(jsonResponse({}, false));
+
+    await expect(fetchAnnouncements()).rejects.toThrow('Failed to fetch announcements');
+  });
+
+  it('maps a populated resource relationship to payload-{slug}', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      jsonResponse({
+        docs: [
+          doc(1, 'Deprecation', {
+            type: 'breaking_change',
+            resource_id: { id: 42, slug: 'quran-api' },
+          }),
+        ],
+        hasNextPage: false,
+        page: 1,
+      }),
+    );
+
+    const [announcement] = await fetchAnnouncements();
+
+    expect(announcement.resource_id).toBe('payload-quran-api');
+  });
+
+  it('omits resource_id when the relationship is null', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      jsonResponse({ docs: [doc(1, 'Plain', { resource_id: null })], hasNextPage: false, page: 1 }),
+    );
+
+    const [announcement] = await fetchAnnouncements();
+
+    expect(announcement.resource_id).toBeUndefined();
+  });
+});
+
+describe('fetchAnnouncements (mock mode)', () => {
+  let fetchAnnouncements: FetchAnnouncements;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.stubEnv('NEXT_PUBLIC_DATA_MODE', 'mock');
+    vi.stubEnv('NEXT_PUBLIC_API_URL', 'https://api.test');
+    vi.stubGlobal('fetch', vi.fn());
+    fetchAnnouncements = (await import('@/modules/resources/infrastructure/announcements-api'))
+      .fetchAnnouncements;
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('does not call the network and returns only active, non-expired mock announcements', async () => {
+    const now = new Date();
+    const expected: Announcement[] = mockAnnouncements.filter((a) => {
+      if (!a.is_active) return false;
+      if (a.expires_at && new Date(a.expires_at) < now) return false;
+      return true;
+    });
+
+    const result = await fetchAnnouncements();
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/modules/resources/infrastructure/announcements-api.ts
+++ b/src/modules/resources/infrastructure/announcements-api.ts
@@ -2,6 +2,49 @@ import type { Announcement } from '@/types/announcement';
 import { DATA_MODE, API_BASE } from '@/shared/infrastructure/data-mode';
 import { mockAnnouncements } from './mock-data';
 
+// Payload REST returns a paginated envelope ({ docs, totalDocs, ... }), not a
+// bare array, so this unwraps docs and normalizes each doc to the frontend
+// Announcement contract. createdAt (Payload's built-in timestamp) becomes
+// created_at, same mapping as developer/infrastructure/notifications-api.ts.
+interface PayloadAnnouncementDoc {
+  id: number | string;
+  type: Announcement['type'];
+  title: string;
+  description: string;
+  resource_id?: { id: number | string; slug: string } | number | string | null;
+  cta_url?: string | null;
+  cta_label?: string | null;
+  createdAt: string;
+  expires_at?: string | null;
+  is_active: boolean;
+}
+
+interface PayloadAnnouncementsResponse {
+  docs: PayloadAnnouncementDoc[];
+}
+
+// Announcements link to Payload-native resources, whose aggregator slug is
+// payload-${slug} (same namespacing as repositories/payload.ts toResource) -
+// the /resources/${slug} detail route resolves against the aggregator.
+function toAnnouncement(doc: PayloadAnnouncementDoc): Announcement {
+  const related = doc.resource_id;
+  const resource_id =
+    related && typeof related === 'object' ? `payload-${related.slug}` : undefined;
+
+  return {
+    id: String(doc.id),
+    type: doc.type,
+    title: doc.title,
+    description: doc.description,
+    resource_id,
+    cta_url: doc.cta_url ?? undefined,
+    cta_label: doc.cta_label ?? undefined,
+    created_at: doc.createdAt,
+    expires_at: doc.expires_at ?? undefined,
+    is_active: doc.is_active,
+  };
+}
+
 export function fetchAnnouncements(): Promise<Announcement[]> {
   if (DATA_MODE === 'mock') {
     const now = new Date();
@@ -14,8 +57,11 @@ export function fetchAnnouncements(): Promise<Announcement[]> {
     );
   }
 
-  return fetch(`${API_BASE}/api/announcements/`).then((res) => {
+  // depth=1 populates the resource_id relationship so the adapter can derive
+  // a routable aggregator slug; limit/sort mirror notifications-api.ts
+  // (newest first, no truncation at Payload's default limit of 10).
+  return fetch(`${API_BASE}/api/announcements/?depth=1&limit=100&sort=-createdAt`).then((res) => {
     if (!res.ok) throw new Error('Failed to fetch announcements');
-    return res.json();
+    return res.json().then((data: PayloadAnnouncementsResponse) => data.docs.map(toAnnouncement));
   });
 }

--- a/src/modules/resources/infrastructure/announcements-api.ts
+++ b/src/modules/resources/infrastructure/announcements-api.ts
@@ -2,7 +2,7 @@ import type { Announcement } from '@/types/announcement';
 import { DATA_MODE, API_BASE } from '@/shared/infrastructure/data-mode';
 import { mockAnnouncements } from './mock-data';
 
-// Payload REST returns a paginated envelope ({ docs, totalDocs, ... }), not a
+// Payload REST returns a paginated envelope ({ docs, hasNextPage, ... }), not a
 // bare array, so this unwraps docs and normalizes each doc to the frontend
 // Announcement contract. createdAt (Payload's built-in timestamp) becomes
 // created_at, same mapping as developer/infrastructure/notifications-api.ts.
@@ -20,7 +20,11 @@ interface PayloadAnnouncementDoc {
 }
 
 interface PayloadAnnouncementsResponse {
-  docs: PayloadAnnouncementDoc[];
+  docs?: PayloadAnnouncementDoc[];
+  hasNextPage?: boolean;
+  nextPage?: number | null;
+  page?: number;
+  totalPages?: number;
 }
 
 // Announcements link to Payload-native resources, whose aggregator slug is
@@ -45,23 +49,46 @@ function toAnnouncement(doc: PayloadAnnouncementDoc): Announcement {
   };
 }
 
-export function fetchAnnouncements(): Promise<Announcement[]> {
+// depth=1 populates the resource_id relationship so the adapter can derive
+// a routable aggregator slug; limit/sort mirror notifications-api.ts
+// (newest first, no truncation at Payload's default limit of 10).
+async function fetchAnnouncementPage(page: number): Promise<PayloadAnnouncementsResponse> {
+  const res = await fetch(
+    `${API_BASE}/api/announcements/?depth=1&limit=100&sort=-createdAt&page=${page}`,
+  );
+  if (!res.ok) throw new Error('Failed to fetch announcements');
+  return res.json();
+}
+
+export async function fetchAnnouncements(): Promise<Announcement[]> {
   if (DATA_MODE === 'mock') {
     const now = new Date();
-    return Promise.resolve(
-      mockAnnouncements.filter((a) => {
-        if (!a.is_active) return false;
-        if (a.expires_at && new Date(a.expires_at) < now) return false;
-        return true;
-      })
-    );
+    return mockAnnouncements.filter((a) => {
+      if (!a.is_active) return false;
+      if (a.expires_at && new Date(a.expires_at) < now) return false;
+      return true;
+    });
   }
 
-  // depth=1 populates the resource_id relationship so the adapter can derive
-  // a routable aggregator slug; limit/sort mirror notifications-api.ts
-  // (newest first, no truncation at Payload's default limit of 10).
-  return fetch(`${API_BASE}/api/announcements/?depth=1&limit=100&sort=-createdAt`).then((res) => {
-    if (!res.ok) throw new Error('Failed to fetch announcements');
-    return res.json().then((data: PayloadAnnouncementsResponse) => data.docs.map(toAnnouncement));
-  });
+  // Payload pages the REST list (default limit 10); walk page 1 onwards and
+  // concatenate docs, preserving the server-side sort order. Loop is guarded
+  // against malformed metadata: stop when hasNextPage is false, when the
+  // response claims no valid forward-moving next page, or when totalPages is
+  // reached - so a buggy/misbehaving server cannot cause an infinite fetch.
+  const docs: PayloadAnnouncementDoc[] = [];
+  let page = 1;
+
+  while (true) {
+    const data = await fetchAnnouncementPage(page);
+    if (Array.isArray(data.docs)) docs.push(...data.docs);
+
+    if (!data.hasNextPage) break;
+    if (typeof data.totalPages === 'number' && page >= data.totalPages) break;
+
+    const nextPage = typeof data.nextPage === 'number' ? data.nextPage : 0;
+    if (!Number.isInteger(nextPage) || nextPage <= page) break;
+    page = nextPage;
+  }
+
+  return docs.map(toAnnouncement);
 }


### PR DESCRIPTION
## Summary

Implements #235 by replacing the mock-only announcements backend path with a real Payload collection.

- Adds an `announcements` Payload collection.
- Restricts create/update/delete operations to admins.
- Public reads only expose active, non-expired announcements.
- Registers the collection in the Payload configuration and regenerates Payload types.
- Adapts the existing announcements API to Payload's paginated response while preserving the frontend `Announcement` contract.
- Resolves populated Payload resource relationships to the existing `payload-${slug}` resource namespace.
- Adds access-control tests covering public, authenticated, and admin behavior.

## Resource references

No fake `resource_id` or `cta_url` values were added.

`resource_id` is backed by a relationship to the real `resources` collection. The frontend adapter uses the populated resource slug so links resolve through the existing resource aggregation layer.

No seed data is committed; announcements can be created through the Payload admin panel using real catalog resources.

## Validation

- `pnpm generate:types` ✅
- `pnpm exec tsc --noEmit` ✅
- `pnpm test` ✅ — 108 tests passed
- Scoped lint on changed files ✅
- `git diff --check` ✅

The repository-wide lint command still reports the pre-existing unrelated lint issues documented in the project.

Closes #235

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added announcements management with titles, descriptions, types, optional resources, calls to action, expiration dates, and active status.
  - Public visitors can view active, non-expired announcements.
  - Administrators can view all announcements and create, update, or delete them.
  - Announcements are now displayed in the frontend with linked resources and normalized metadata.

- **Bug Fixes**
  - Improved handling of announcement data, relationships, optional fields, and API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->