### PR TITLE
fix(auth): handle expired and invalid sessions during API requests - PR against issue #165

### DIFF
--- a/src/__tests__/LoginForm.test.tsx
+++ b/src/__tests__/LoginForm.test.tsx
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { LoginForm } from '@/modules/auth/components/LoginForm';
+import { SESSION_EXPIRED_REASON } from '@/shared/infrastructure/session-expiry';
+import { LanguageProvider } from '@/shared/ui/i18n';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({
+    login: vi.fn(),
+    loading: false,
+    error: SESSION_EXPIRED_REASON,
+  }),
+}));
+
+describe('LoginForm session expiry message', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it.each([
+    ['en', 'Your session has expired. Please log in again.'],
+    ['ar', 'انتهت صلاحية جلستك. يُرجى تسجيل الدخول مرة أخرى.'],
+  ] as const)('shows the session-expired reason in %s', async (locale, message) => {
+    localStorage.setItem('ratq_locale', locale);
+
+    render(
+      <LanguageProvider>
+        <LoginForm />
+      </LanguageProvider>
+    );
+
+    expect(await screen.findByText(message)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/payloadError.test.ts
+++ b/src/__tests__/payloadError.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { payloadErrorMessage } from '@/shared/infrastructure/payload-error';
+import { PAYLOAD_API_BASE } from '@/shared/infrastructure/payload-config';
+import { subscribeToSessionExpiry } from '@/shared/infrastructure/session-expiry';
+
+const permissionMessage = 'You are not allowed to perform this action.';
+
+function jwtWithExp(exp: number): string {
+  const header = btoa(JSON.stringify({ alg: 'HS256' }));
+  const payload = btoa(JSON.stringify({ exp }));
+  return `${header}.${payload}.signature`;
+}
+
+function errorResponse(status: number, message: string): Response {
+  return new Response(JSON.stringify({ errors: [{ message }] }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('payloadErrorMessage session validation', () => {
+  const onSessionExpired = vi.fn();
+  let unsubscribe: (() => void) | undefined;
+
+  beforeEach(() => {
+    localStorage.clear();
+    onSessionExpired.mockClear();
+    unsubscribe = subscribeToSessionExpiry(onSessionExpired);
+  });
+
+  afterEach(() => {
+    unsubscribe?.();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('signals session expiry when Payload rejects an expired stored token', async () => {
+    const token = jwtWithExp(Math.floor(Date.now() / 1000) - 60);
+    localStorage.setItem('ratq_access_token', token);
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ user: null }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await payloadErrorMessage(errorResponse(403, permissionMessage), 'Failed to publish resource', {
+      authenticated: true,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(`${PAYLOAD_API_BASE}/users/me`, {
+      cache: 'no-store',
+      headers: { Authorization: `JWT ${token}` },
+      signal: expect.any(AbortSignal),
+    });
+    expect(onSessionExpired).toHaveBeenCalledOnce();
+  });
+
+  it.each([401, 403])(
+    'signals session expiry when Payload rejects a malformed stored token with %i',
+    async (status) => {
+      localStorage.setItem('ratq_access_token', 'invalid_access_token');
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(
+          new Response(JSON.stringify({ user: null }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        )
+      );
+
+      await payloadErrorMessage(
+        errorResponse(status, permissionMessage),
+        'Failed to publish resource',
+        { authenticated: true }
+      );
+
+      expect(onSessionExpired).toHaveBeenCalledOnce();
+    }
+  );
+
+  it('preserves a genuine permission error when the stored session is valid', async () => {
+    localStorage.setItem(
+      'ratq_access_token',
+      jwtWithExp(Math.floor(Date.now() / 1000) + 3600)
+    );
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ user: { id: 42 } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+
+    const message = await payloadErrorMessage(
+      errorResponse(403, permissionMessage),
+      'Failed to delete resource',
+      { authenticated: true }
+    );
+
+    expect(message).toBe(permissionMessage);
+    expect(onSessionExpired).not.toHaveBeenCalled();
+  });
+
+  it('does not probe the session for validation errors', async () => {
+    localStorage.setItem('ratq_access_token', 'stored-token');
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const message = await payloadErrorMessage(
+      errorResponse(400, 'Name is required'),
+      'Failed to publish resource',
+      { authenticated: true }
+    );
+
+    expect(message).toBe('Name is required');
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(onSessionExpired).not.toHaveBeenCalled();
+  });
+
+  it('does not probe an ambiguous failure when no token is stored', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const message = await payloadErrorMessage(
+      errorResponse(403, permissionMessage),
+      'Failed to publish resource',
+      { authenticated: true }
+    );
+
+    expect(message).toBe(permissionMessage);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(onSessionExpired).not.toHaveBeenCalled();
+  });
+
+  it('preserves the original error when session verification is inconclusive', async () => {
+    localStorage.setItem('ratq_access_token', 'stored-token');
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network unavailable')));
+
+    const message = await payloadErrorMessage(
+      errorResponse(403, permissionMessage),
+      'Failed to delete resource',
+      { authenticated: true }
+    );
+
+    expect(message).toBe(permissionMessage);
+    expect(onSessionExpired).not.toHaveBeenCalled();
+  });
+
+  it('does not validate a stale stored token for an unauthenticated request', async () => {
+    localStorage.setItem('ratq_access_token', 'stale-token');
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ user: null }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const message = await payloadErrorMessage(
+      errorResponse(401, 'Invalid credentials'),
+      'Login failed'
+    );
+
+    expect(message).toBe('Invalid credentials');
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(onSessionExpired).not.toHaveBeenCalled();
+  });
+
+  it('does not expire a replacement session when an older probe completes', async () => {
+    localStorage.setItem('ratq_access_token', 'stale-token');
+    let resolveProbe: ((response: Response) => void) | undefined;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(
+        () => new Promise<Response>((resolve) => {
+          resolveProbe = resolve;
+        })
+      )
+    );
+
+    const messagePromise = payloadErrorMessage(
+      errorResponse(403, permissionMessage),
+      'Failed to publish resource',
+      { authenticated: true }
+    );
+    await vi.waitFor(() => expect(resolveProbe).toBeTypeOf('function'));
+    localStorage.setItem('ratq_access_token', 'replacement-token');
+    expect(localStorage.getItem('ratq_access_token')).toBe('replacement-token');
+    resolveProbe?.(
+      new Response(JSON.stringify({ user: null }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    await messagePromise;
+
+    expect(localStorage.getItem('ratq_access_token')).toBe('replacement-token');
+    expect(onSessionExpired).not.toHaveBeenCalled();
+  });
+
+  it('preserves the original error when session verification times out', async () => {
+    vi.useFakeTimers();
+    localStorage.setItem('ratq_access_token', 'stored-token');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(
+        (_url: string, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () => {
+              reject(new DOMException('Aborted', 'AbortError'));
+            });
+          })
+      )
+    );
+
+    const messagePromise = payloadErrorMessage(
+      errorResponse(403, permissionMessage),
+      'Failed to delete resource',
+      { authenticated: true }
+    );
+    await vi.runAllTimersAsync();
+
+    await expect(
+      Promise.race([messagePromise, Promise.resolve('probe-still-pending')])
+    ).resolves.toBe(permissionMessage);
+    expect(onSessionExpired).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/useAuth.test.tsx
+++ b/src/__tests__/useAuth.test.tsx
@@ -4,7 +4,17 @@ import { renderToString } from 'react-dom/server';
 import { render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AuthProvider, useAuth } from '@/hooks/useAuth';
+import {
+  SESSION_EXPIRED_REASON,
+  notifySessionExpired,
+} from '@/shared/infrastructure/session-expiry';
 import type { User } from '@/types/resource';
+
+const mockReplace = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mockReplace }),
+}));
 
 const storedUser: User = {
   id: 42,
@@ -28,12 +38,15 @@ function storeSession(exp: number) {
 }
 
 function AuthStateProbe() {
-  const { user, loading } = useAuth();
+  const { user, loading, error } = useAuth();
 
   return (
-    <p data-testid="auth-state">
-      {loading ? 'loading' : user?.email ?? 'anonymous'}
-    </p>
+    <>
+      <p data-testid="auth-state">
+        {loading ? 'loading' : user?.email ?? 'anonymous'}
+      </p>
+      {error && <p data-testid="auth-error">{error}</p>}
+    </>
   );
 }
 
@@ -41,6 +54,7 @@ describe('AuthProvider hydration', () => {
   beforeEach(() => {
     localStorage.clear();
     vi.restoreAllMocks();
+    mockReplace.mockClear();
   });
 
   it('hydrates without a mismatch and restores a stored session', async () => {
@@ -118,5 +132,30 @@ describe('AuthProvider hydration', () => {
     expect(localStorage.getItem('ratq_access_token')).toBeNull();
     expect(localStorage.getItem('ratq_refresh_token')).toBeNull();
     expect(localStorage.getItem('ratq_user')).toBeNull();
+  });
+
+  it('clears an active stale session and directs the user to log in again', async () => {
+    storeSession(Math.floor(Date.now() / 1000) + 3600);
+
+    render(
+      <AuthProvider>
+        <AuthStateProbe />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auth-state')).toHaveTextContent(storedUser.email);
+    });
+
+    act(() => notifySessionExpired());
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auth-state')).toHaveTextContent('anonymous');
+    });
+    expect(localStorage.getItem('ratq_access_token')).toBeNull();
+    expect(localStorage.getItem('ratq_refresh_token')).toBeNull();
+    expect(localStorage.getItem('ratq_user')).toBeNull();
+    expect(screen.getByTestId('auth-error')).toHaveTextContent(SESSION_EXPIRED_REASON);
+    expect(mockReplace).toHaveBeenCalledWith('/login');
   });
 });

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -8,6 +8,7 @@ import {
   useCallback,
   type ReactNode,
 } from 'react';
+import { useRouter } from 'next/navigation';
 import { login as loginUseCase } from '@/modules/auth/application/use-cases/login';
 import { register as registerUseCase } from '@/modules/auth/application/use-cases/register';
 import { completeOAuth } from '@/modules/auth/application/use-cases/complete-oauth';
@@ -19,6 +20,10 @@ import {
   getStoredUser,
   setStoredUser,
 } from '@/shared/infrastructure/token-storage';
+import {
+  SESSION_EXPIRED_REASON,
+  subscribeToSessionExpiry,
+} from '@/shared/infrastructure/session-expiry';
 import type { User } from '@/types/resource';
 
 // Discards a stale session up front instead of letting an expired token fail
@@ -51,9 +56,15 @@ type AuthContextType = {
 const AuthContext = createContext<AuthContextType | null>(null);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
+  const router = useRouter();
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  const logout = useCallback(() => {
+    logoutUseCase();
+    setUser(null);
+  }, []);
 
   useEffect(() => {
     /* eslint-disable react-hooks/set-state-in-effect -- Restore browser-only auth state after hydration so the server and first client render match. */
@@ -61,6 +72,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setLoading(false);
     /* eslint-enable react-hooks/set-state-in-effect */
   }, []);
+
+  useEffect(
+    () =>
+      subscribeToSessionExpiry(() => {
+        logout();
+        setError(SESSION_EXPIRED_REASON);
+        router.replace('/login');
+      }),
+    [logout, router]
+  );
 
   const login = useCallback(async (email: string, password: string) => {
     setLoading(true);
@@ -118,11 +139,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     },
     []
   );
-
-  const logout = useCallback(() => {
-    logoutUseCase();
-    setUser(null);
-  }, []);
 
   return (
     <AuthContext.Provider

--- a/src/modules/auth/components/LoginForm.tsx
+++ b/src/modules/auth/components/LoginForm.tsx
@@ -4,12 +4,16 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/hooks/useAuth';
 import { githubOAuthUrl } from '@/modules/auth/application/use-cases/get-github-oauth-url';
+import { SESSION_EXPIRED_REASON } from '@/shared/infrastructure/session-expiry';
+import { useLanguage } from '@/shared/ui/i18n';
 
 export function LoginForm() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const { login, loading, error } = useAuth();
   const router = useRouter();
+  const { t } = useLanguage();
+  const displayedError = error === SESSION_EXPIRED_REASON ? t.auth.sessionExpired : error;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -22,9 +26,9 @@ export function LoginForm() {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-5">
-      {error && (
+      {displayedError && (
         <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm leading-6 text-red-700">
-          {error}
+          {displayedError}
         </div>
       )}
 

--- a/src/modules/developer/infrastructure/api-keys-api.ts
+++ b/src/modules/developer/infrastructure/api-keys-api.ts
@@ -56,7 +56,11 @@ export async function createDeveloperApiKey(resourceId: number, scope: string, n
     },
     body: JSON.stringify({ name: name || `key-${resourceId}`, resource: resourceId - 200_000, scope }),
   });
-  if (!res.ok) throw new Error(await payloadErrorMessage(res, 'Failed to create API key'));
+  if (!res.ok) {
+    throw new Error(
+      await payloadErrorMessage(res, 'Failed to create API key', { authenticated: true })
+    );
+  }
   const result: { doc: PayloadApiKeyDoc } = await res.json();
   return toApiKey(result.doc);
 }
@@ -66,6 +70,10 @@ export async function revokeDeveloperApiKey(keyId: number) {
     method: 'DELETE',
     headers: { Authorization: `JWT ${getAccessToken()}` },
   });
-  if (!res.ok) throw new Error(await payloadErrorMessage(res, 'Failed to revoke API key'));
+  if (!res.ok) {
+    throw new Error(
+      await payloadErrorMessage(res, 'Failed to revoke API key', { authenticated: true })
+    );
+  }
   return res.json();
 }

--- a/src/modules/developer/infrastructure/notifications-api.ts
+++ b/src/modules/developer/infrastructure/notifications-api.ts
@@ -45,7 +45,13 @@ export async function markNotificationAsRead(notificationId: number) {
     },
     body: JSON.stringify({ read: true }),
   });
-  if (!res.ok) throw new Error(await payloadErrorMessage(res, 'Failed to mark notification as read'));
+  if (!res.ok) {
+    throw new Error(
+      await payloadErrorMessage(res, 'Failed to mark notification as read', {
+        authenticated: true,
+      })
+    );
+  }
   return res.json();
 }
 
@@ -64,6 +70,12 @@ export async function markAllNotificationsAsRead() {
       body: JSON.stringify({ read: true }),
     }
   );
-  if (!res.ok) throw new Error(await payloadErrorMessage(res, 'Failed to mark all notifications as read'));
+  if (!res.ok) {
+    throw new Error(
+      await payloadErrorMessage(res, 'Failed to mark all notifications as read', {
+        authenticated: true,
+      })
+    );
+  }
   return res.json();
 }

--- a/src/modules/developer/infrastructure/resources-api.ts
+++ b/src/modules/developer/infrastructure/resources-api.ts
@@ -37,7 +37,11 @@ export async function createDeveloperResource(data: CreateResourceInput): Promis
     },
     body: JSON.stringify(data),
   });
-  if (!res.ok) throw new Error(await payloadErrorMessage(res, 'Failed to publish resource'));
+  if (!res.ok) {
+    throw new Error(
+      await payloadErrorMessage(res, 'Failed to publish resource', { authenticated: true })
+    );
+  }
   const result: { doc: PayloadResourceDoc } = await res.json();
   return toResource(result.doc);
 }
@@ -56,7 +60,11 @@ export async function updateDeveloperResource(id: number, data: UpdateResourceIn
     },
     body: JSON.stringify(data),
   });
-  if (!res.ok) throw new Error(await payloadErrorMessage(res, 'Failed to update resource'));
+  if (!res.ok) {
+    throw new Error(
+      await payloadErrorMessage(res, 'Failed to update resource', { authenticated: true })
+    );
+  }
   const result: { doc: PayloadResourceDoc } = await res.json();
   return toResource(result.doc);
 }
@@ -66,6 +74,10 @@ export async function deleteDeveloperResource(id: number) {
     method: 'DELETE',
     headers: { Authorization: `JWT ${getAccessToken()}` },
   });
-  if (!res.ok) throw new Error(await payloadErrorMessage(res, 'Failed to delete resource'));
+  if (!res.ok) {
+    throw new Error(
+      await payloadErrorMessage(res, 'Failed to delete resource', { authenticated: true })
+    );
+  }
   return res.json();
 }

--- a/src/modules/resources/infrastructure/access-requests-api.ts
+++ b/src/modules/resources/infrastructure/access-requests-api.ts
@@ -45,7 +45,11 @@ export async function submitAccessRequest(resourceId: number, message: string): 
     },
     body: JSON.stringify({ resource: resourceId - 200_000, message }),
   });
-  if (!res.ok) throw new Error(await payloadErrorMessage(res, 'Failed to submit request'));
+  if (!res.ok) {
+    throw new Error(
+      await payloadErrorMessage(res, 'Failed to submit request', { authenticated: true })
+    );
+  }
   const result: { doc: PayloadAccessRequestDoc } = await res.json();
   return toAccessRequest(result.doc);
 }

--- a/src/modules/resources/infrastructure/comments-api.ts
+++ b/src/modules/resources/infrastructure/comments-api.ts
@@ -45,7 +45,11 @@ export async function postComment(resourceId: number, content: string): Promise<
     },
     body: JSON.stringify({ content, resource: resourceId - 200_000 }),
   });
-  if (!res.ok) throw new Error(await payloadErrorMessage(res, 'Failed to post comment'));
+  if (!res.ok) {
+    throw new Error(
+      await payloadErrorMessage(res, 'Failed to post comment', { authenticated: true })
+    );
+  }
   const result: { doc: PayloadCommentDoc } = await res.json();
   return toComment(result.doc);
 }

--- a/src/modules/resources/infrastructure/reports-api.ts
+++ b/src/modules/resources/infrastructure/reports-api.ts
@@ -40,7 +40,11 @@ export async function submitReport(resourceId: number, reason: ReportReason, det
     },
     body: JSON.stringify({ resource: resourceId - 200_000, reason, details }),
   });
-  if (!res.ok) throw new Error(await payloadErrorMessage(res, 'Failed to submit report'));
+  if (!res.ok) {
+    throw new Error(
+      await payloadErrorMessage(res, 'Failed to submit report', { authenticated: true })
+    );
+  }
   const result: { doc: PayloadReportDoc } = await res.json();
   return toReport(result.doc);
 }

--- a/src/shared/infrastructure/payload-error.ts
+++ b/src/shared/infrastructure/payload-error.ts
@@ -1,6 +1,58 @@
+import { PAYLOAD_API_BASE } from '@/shared/infrastructure/payload-config';
+import { notifySessionExpired } from '@/shared/infrastructure/session-expiry';
+import { getAccessToken } from '@/shared/infrastructure/token-storage';
+
+const SESSION_PROBE_TIMEOUT_MS = 5_000;
+
+interface PayloadErrorOptions {
+  // True only when the failed request sent the stored Payload JWT.
+  authenticated?: boolean;
+}
+
 // Single copy of the Payload error-shape parser. Shared across modules
 // since every Payload-backed write endpoint needs the same fallback logic.
-export async function payloadErrorMessage(res: Response, fallback: string): Promise<string> {
+export async function payloadErrorMessage(
+  res: Response,
+  fallback: string,
+  options: PayloadErrorOptions = {}
+): Promise<string> {
   const data = await res.json().catch(() => null);
+  const invalidToken =
+    options.authenticated && (res.status === 401 || res.status === 403)
+      ? await invalidStoredSessionToken()
+      : null;
+
+  if (invalidToken && getAccessToken() === invalidToken) {
+    notifySessionExpired();
+  }
+
   return data?.errors?.[0]?.data?.errors?.[0]?.message || data?.errors?.[0]?.message || fallback;
+}
+
+async function invalidStoredSessionToken(): Promise<string | null> {
+  const token = getAccessToken();
+  if (!token) return null;
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), SESSION_PROBE_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(`${PAYLOAD_API_BASE}/users/me`, {
+      cache: 'no-store',
+      headers: { Authorization: `JWT ${token}` },
+      signal: controller.signal,
+    });
+    if (!res.ok) return null;
+
+    const data: unknown = await res.json();
+    return isRecord(data) && data.user === null ? token : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
 }

--- a/src/shared/infrastructure/session-expiry.ts
+++ b/src/shared/infrastructure/session-expiry.ts
@@ -1,0 +1,16 @@
+const SESSION_EXPIRED_EVENT = 'ratq:session-expired';
+
+export const SESSION_EXPIRED_REASON = 'session_expired';
+
+export function notifySessionExpired(): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new Event(SESSION_EXPIRED_EVENT));
+}
+
+export function subscribeToSessionExpiry(listener: () => void): () => void {
+  if (typeof window === 'undefined') return () => {};
+
+  const handleSessionExpiry = () => listener();
+  window.addEventListener(SESSION_EXPIRED_EVENT, handleSessionExpiry);
+  return () => window.removeEventListener(SESSION_EXPIRED_EVENT, handleSessionExpiry);
+}

--- a/src/shared/ui/i18n/messages/ar.json
+++ b/src/shared/ui/i18n/messages/ar.json
@@ -471,7 +471,8 @@
     "publisher": "ناشر",
     "publisherDescription": "أشارك الموارد وأديرها",
     "createAccount": "إنشاء الحساب",
-    "creatingAccount": "جاري إنشاء الحساب..."
+    "creatingAccount": "جاري إنشاء الحساب...",
+    "sessionExpired": "انتهت صلاحية جلستك. يُرجى تسجيل الدخول مرة أخرى."
   },
   "contributors": {
     "pageTitle": "المساهمون",

--- a/src/shared/ui/i18n/messages/en.json
+++ b/src/shared/ui/i18n/messages/en.json
@@ -471,7 +471,8 @@
     "publisher": "Publisher",
     "publisherDescription": "Share and manage resources",
     "createAccount": "Create account",
-    "creatingAccount": "Creating account..."
+    "creatingAccount": "Creating account...",
+    "sessionExpired": "Your session has expired. Please log in again."
   },
   "contributors": {
     "pageTitle": "Contributors",


### PR DESCRIPTION
## Description

Closes #165

## Summary

This PR adds session-expiry handling for authenticated API requests.

Previously, an expired or invalid JWT could cause a protected API request to fail without consistently clearing the stale authentication state or guiding the user back to login.

The implementation now detects authentication-related API failures, verifies whether the current session is still valid, and triggers the session-expired flow only when the session is actually invalid.

This also preserves the distinction between:

* an expired or invalid session
* a valid authenticated session that does not have permission to perform an action

## Changes

* Add shared session-expiry event handling and subscriptions.
* Detect authentication-related `401` / `403` API responses.
* Probe the current session before treating an authorization failure as session expiry.
* Clear stale authentication state when the session is confirmed invalid.
* Redirect users with expired or invalid sessions to `/login`.
* Display a localized session-expired message after redirection.
* Pass authentication context through affected API infrastructure modules.
* Add tests for:

  * `payloadErrorMessage`
  * `useAuth`
  * `LoginForm`

## Session-expiry flow

```text
Protected API request
        ↓
401 / 403 response
        ↓
Check current session
        ↓
Session invalid
        ↓
Emit session-expiry event
        ↓
Clear authentication state
        ↓
Redirect to /login
        ↓
Display session-expired message
```

A genuine permission denial follows a different path:

```text
Protected API request
        ↓
403 Forbidden
        ↓
Check current session
        ↓
Session still valid
        ↓
Do not expire session
        ↓
Keep user logged in
        ↓
Display permission error
```

## Manual Testing

The following scenarios were verified manually.

### Expired JWT

Generated a correctly signed JWT with an expiration timestamp in the past and used it for an authenticated API request.

Result:

* API request rejected
* session validation failed
* authentication state cleared
* user redirected to `/login`
* session-expired message displayed

✅ Passed

### Invalid JWT

Modified the stored JWT so that the token was no longer valid and triggered a protected API request.

Result:

* invalid session detected
* authentication state cleared
* user redirected to `/login`
* session-expired message displayed

✅ Passed

### Valid session with genuine permission denial

Logged in using a valid Publisher account and attempted to update a resource owned by another user.

Observed:

```text
PATCH protected resource → 403
GET /api/users/me        → 200
```

Result:

* permission error displayed
* Publisher remained authenticated
* no session-expiry event triggered
* no redirect to `/login`

✅ Passed

This verifies that genuine authorization failures are not incorrectly treated as expired sessions.

## Automated Testing

After rebasing onto the latest `beta`:

```text
Test Files  31 passed (31)
Tests       180 passed (180)
```

TypeScript validation also passes:

```bash
npx tsc --noEmit
```

## Commits

```text
91ab938 fix(auth): detect expired sessions from API responses
22f2f3c fix(auth): handle session expiry and redirect to login
```

## Related UX Finding

While testing the new session-expired message, a separate authentication UI issue was discovered.

Authentication errors can persist when navigating between the login and registration pages. The behavior is not specific to session expiry; it can also be reproduced using a normal invalid-credentials error such as:

`The email or password provided is incorrect.`

Because this is a broader authentication error-state lifecycle issue and can be reproduced independently of session-expiry handling, it is intentionally **not included in this PR**.

It should be tracked separately so that #165 remains focused on expired/invalid session detection and handling.

## Checklist

* [x] Expired JWT redirects to login
* [x] Invalid JWT redirects to login
* [x] Session-expired message is displayed
* [x] Authentication state is cleared on confirmed session expiry
* [x] Genuine `403` permission errors do not log out valid users
* [x] Permission errors remain visible to the authenticated user
* [x] Unit tests added/updated
* [x] Full test suite passes
* [x] TypeScript check passes
* [x] Branch rebased onto latest `beta`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection of expired or invalid sessions.
  * Users are signed out and redirected to the login page when their session expires.
  * Added localized session-expiration messages in English and Arabic.
  * Improved error handling for authenticated requests to preserve accurate session and permission errors.

* **Tests**
  * Added coverage for localized messages, session expiry, redirects, token validation, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->