### PR TITLE
fix(auth): clear stale authentication errors on navigation login and …

### DIFF
--- a/src/__tests__/useAuth.test.tsx
+++ b/src/__tests__/useAuth.test.tsx
@@ -119,4 +119,46 @@ describe('AuthProvider hydration', () => {
     expect(localStorage.getItem('ratq_refresh_token')).toBeNull();
     expect(localStorage.getItem('ratq_user')).toBeNull();
   });
+
+  it('clears error state when clearError is called', async () => {
+    const loginModule = await import('@/modules/auth/application/use-cases/login');
+    vi.spyOn(loginModule, 'login').mockRejectedValue(new Error('Invalid credentials'));
+
+    function ErrorProbe() {
+      const { error, clearError, login } = useAuth();
+      return (
+        <div>
+          <span data-testid="error-msg">{error ?? 'none'}</span>
+          <button type="button" data-testid="fail-login" onClick={() => login('wrong@test.com', 'wrongpass')}>
+            Trigger Login
+          </button>
+          <button type="button" data-testid="clear-btn" onClick={clearError}>
+            Clear
+          </button>
+        </div>
+      );
+    }
+
+    render(
+      <AuthProvider>
+        <ErrorProbe />
+      </AuthProvider>
+    );
+
+    expect(screen.getByTestId('error-msg')).toHaveTextContent('none');
+
+    await act(async () => {
+      screen.getByTestId('fail-login').click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('error-msg')).toHaveTextContent('Invalid credentials');
+    });
+
+    await act(async () => {
+      screen.getByTestId('clear-btn').click();
+    });
+
+    expect(screen.getByTestId('error-msg')).toHaveTextContent('none');
+  });
 });

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -37,6 +37,7 @@ type AuthContextType = {
   user: User | null;
   loading: boolean;
   error: string | null;
+  clearError: () => void;
   login: (email: string, password: string) => Promise<{ success: boolean; error?: string }>;
   loginWithToken: (token: string) => Promise<{ success: boolean; error?: string }>;
   register: (
@@ -124,12 +125,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUser(null);
   }, []);
 
+  const clearError = useCallback(() => {
+    setError(null);
+  }, []);
+
   return (
     <AuthContext.Provider
       value={{
         user,
         loading,
         error,
+        clearError,
         login,
         loginWithToken,
         register,

--- a/src/modules/auth/components/LoginForm.tsx
+++ b/src/modules/auth/components/LoginForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/hooks/useAuth';
 import { githubOAuthUrl } from '@/modules/auth/application/use-cases/get-github-oauth-url';
@@ -8,8 +8,12 @@ import { githubOAuthUrl } from '@/modules/auth/application/use-cases/get-github-
 export function LoginForm() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const { login, loading, error } = useAuth();
+  const { login, loading, error, clearError } = useAuth();
   const router = useRouter();
+
+  useEffect(() => {
+    clearError();
+  }, [clearError]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/modules/auth/components/RegisterForm.tsx
+++ b/src/modules/auth/components/RegisterForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/hooks/useAuth';
 import { useLanguage } from '@/shared/ui/i18n';
@@ -10,10 +10,14 @@ export function RegisterForm() {
   const [password, setPassword] = useState('');
   const [displayName, setDisplayName] = useState('');
   const [role, setRole] = useState<'developer' | 'publisher'>('developer');
-  const { register, loading, error } = useAuth();
+  const { register, loading, error, clearError } = useAuth();
   const { t } = useLanguage();
   const router = useRouter();
   const copy = t.auth;
+
+  useEffect(() => {
+    clearError();
+  }, [clearError]);
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();


### PR DESCRIPTION
Closes #246 

## Change Summary
— Added the 'clear Error' function to 'Auth Provider' in'src/hooks/useAuth.tsx' and made it accessible via 'Auth Context'.
— Added a 'use Effect' hook to 'Login Form' and 'Register Form' to automatically clear stale authentication errors when the component is mounted, ensuring clean state transitions.
— Unit tests in'src/tests/useAuth.test.tsx' to ensure that 'clear Error' successfully resets the error state to 'null'.

### Testing
— Executed 'NPM run test:run' and verified that all 26 test files and 154 subtests completed successfully (100% pass rate).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication errors are now cleared when opening the login or registration form, preventing outdated messages from persisting.

* **Tests**
  * Added coverage confirming failed login errors appear correctly and can be cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->