### PR TITLE
fix: verify resource ownership or approved access request on API key …

### DIFF
--- a/payload-backend/src/collections/APIKeys.test.ts
+++ b/payload-backend/src/collections/APIKeys.test.ts
@@ -73,8 +73,27 @@ describe('APIKeys access.delete (isOwner)', () => {
   })
 })
 
+interface CountArgs {
+  collection: string
+  where: Record<string, unknown>
+}
+
+interface BeforeValidateArgs {
+  req: {
+    user: { id: number | string; role?: string } | null
+    payload: {
+      findByID: (args: { collection: string; id: unknown; depth?: number }) => Promise<{ id: number; owner: unknown } | null>
+      count: (args: CountArgs) => Promise<{ totalDocs: number }>
+    }
+  }
+  data: Record<string, unknown>
+  operation: string
+}
+
 describe('APIKeys beforeValidate hook (ownership/access guard)', () => {
-  const hook = APIKeys.hooks!.beforeValidate![0] as (args: any) => Promise<unknown>
+  const hook = APIKeys.hooks!.beforeValidate![0] as (
+    args: BeforeValidateArgs,
+  ) => Promise<Record<string, unknown>>
 
   it('allows API key creation if the user is the resource owner', async () => {
     const payload = {
@@ -91,10 +110,10 @@ describe('APIKeys beforeValidate hook (ownership/access guard)', () => {
   })
 
   it('allows API key creation if the user has an approved access request', async () => {
-    let capturedQuery: any
+    let capturedQuery: CountArgs | undefined
     const payload = {
       findByID: async () => ({ id: 10, owner: 99 }),
-      count: async (args: any) => {
+      count: async (args: CountArgs) => {
         capturedQuery = args
         return { totalDocs: 1 }
       },
@@ -107,8 +126,8 @@ describe('APIKeys beforeValidate hook (ownership/access guard)', () => {
     })
 
     expect(result).toBe(data)
-    expect(capturedQuery.collection).toBe('access-requests')
-    expect(capturedQuery.where).toEqual({
+    expect(capturedQuery?.collection).toBe('access-requests')
+    expect(capturedQuery?.where).toEqual({
       and: [
         { resource: { equals: 10 } },
         { applicant: { equals: 1 } },

--- a/payload-backend/src/collections/APIKeys.test.ts
+++ b/payload-backend/src/collections/APIKeys.test.ts
@@ -73,6 +73,65 @@ describe('APIKeys access.delete (isOwner)', () => {
   })
 })
 
+describe('APIKeys beforeValidate hook (ownership/access guard)', () => {
+  const hook = APIKeys.hooks!.beforeValidate![0] as (args: any) => Promise<unknown>
+
+  it('allows API key creation if the user is the resource owner', async () => {
+    const payload = {
+      findByID: async () => ({ id: 10, owner: 1 }),
+      count: async () => ({ totalDocs: 0 }),
+    }
+    const data = { resource: 10, name: 'Owner Key' }
+    const result = await hook({
+      req: { user: { id: 1, role: 'developer' }, payload },
+      data,
+      operation: 'create',
+    })
+    expect(result).toBe(data)
+  })
+
+  it('allows API key creation if the user has an approved access request', async () => {
+    let capturedQuery: any
+    const payload = {
+      findByID: async () => ({ id: 10, owner: 99 }),
+      count: async (args: any) => {
+        capturedQuery = args
+        return { totalDocs: 1 }
+      },
+    }
+    const data = { resource: 10, name: 'Approved Key' }
+    const result = await hook({
+      req: { user: { id: 1, role: 'developer' }, payload },
+      data,
+      operation: 'create',
+    })
+
+    expect(result).toBe(data)
+    expect(capturedQuery.collection).toBe('access-requests')
+    expect(capturedQuery.where).toEqual({
+      and: [
+        { resource: { equals: 10 } },
+        { applicant: { equals: 1 } },
+        { status: { equals: 'approved' } },
+      ],
+    })
+  })
+
+  it('rejects API key creation if user is neither owner nor approved applicant', async () => {
+    const payload = {
+      findByID: async () => ({ id: 10, owner: 99 }),
+      count: async () => ({ totalDocs: 0 }),
+    }
+    await expect(
+      hook({
+        req: { user: { id: 1, role: 'developer' }, payload },
+        data: { resource: 10, name: 'Unauthorized Key' },
+        operation: 'create',
+      }),
+    ).rejects.toThrow('You do not have permission to generate an API key for this resource.')
+  })
+})
+
 describe('APIKeys beforeChange hook', () => {
   const hook = APIKeys.hooks!.beforeChange![0] as (args: {
     req: { user: unknown; context: Record<string, unknown> }

--- a/payload-backend/src/collections/APIKeys.ts
+++ b/payload-backend/src/collections/APIKeys.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto'
+import { APIError } from 'payload'
 import type { Access, CollectionConfig } from 'payload'
 
 const isOwner: Access = ({ req }) => {
@@ -35,6 +36,53 @@ export const APIKeys: CollectionConfig = {
     useAsTitle: 'name',
   },
   hooks: {
+    beforeValidate: [
+      async ({ req, data, operation }) => {
+        if (operation !== 'create' || !data || !req.user) return data
+        if (req.user.role === 'admin') return data
+
+        const resourceId =
+          typeof data.resource === 'object' ? data.resource.id : data.resource
+        if (!resourceId) return data
+
+        const resource = await req.payload.findByID({
+          collection: 'resources',
+          id: resourceId,
+          depth: 0,
+        })
+
+        if (!resource) {
+          throw new APIError('Resource not found.', 404)
+        }
+
+        const resourceOwnerId =
+          typeof resource.owner === 'object' ? resource.owner.id : resource.owner
+
+        if (resourceOwnerId === req.user.id) {
+          return data
+        }
+
+        const { totalDocs } = await req.payload.count({
+          collection: 'access-requests',
+          where: {
+            and: [
+              { resource: { equals: resourceId } },
+              { applicant: { equals: req.user.id } },
+              { status: { equals: 'approved' } },
+            ],
+          },
+        })
+
+        if (totalDocs > 0) {
+          return data
+        }
+
+        throw new APIError(
+          'You do not have permission to generate an API key for this resource.',
+          403,
+        )
+      },
+    ],
     beforeChange: [
       ({ req, data, operation }) => {
         if (req.user) {


### PR DESCRIPTION
## Summary
Fixes #152 - API key creation security vulnerability where any authenticated user could generate a working API key bound to arbitrary resources without validating ownership or approved access.

## Description of Changes
- Backend Validation Hook (`APIKeys.ts`): 
  - Introduced a beforeValidate hook triggered on create operations.
  - Implemented an Admin Bypass check for administrator roles (req.user.role === 'admin').
  - Added a Resource Ownership Check using req.payload.findByID to verify if the requesting user owns the target resource.
  - Added an Approved Access Request Check using req.payload.count to query the access-requests collection ensuring the user holds an active status (status: 'approved') for the target resource.
  - Throws an explicit APIError with a 403 Forbidden status code and clear messaging ('You do not have permission to generate an API key for this resource.') if neither condition is satisfied.

- Unit Testing (`APIKeys.test.ts`):
  - Extended the test suite with a dedicated describe('APIKeys beforeValidate hook (ownership/access guard)') block covering all mandatory acceptance criteria:
    1. Resource Owner Success: Validates that resource owners can successfully generate API keys for their own resources.
    2. Approved Access Request Success: Validates that users with an approved access request can successfully create API keys.
    3. Unauthorized Rejection: Validates that users lacking both ownership and approved requests are rejected with an explicit APIError.

- End-to-End Verification (Admin UI):
  - Performed live testing across user roles via the Payload Admin Panel:
    - Owner scenario: Verified successful API key creation for resource owners.
    - Unauthorized scenario: Verified immediate rejection and error feedback for non-owners.
    - Approved Access Request scenario: Verified successful key creation after obtaining an approved access request.

## Testing & Verification
- All backend unit tests passed successfully (147/147 tests passed, including APIKeys.test.ts).
- Clean scope limited exclusively to APIKeys.ts and APIKeys.test.ts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * API key creation is now limited to resource owners, administrators, and users with approved access requests.
  * Unauthorized attempts receive a clear access-denied response.
  * Requests for unavailable resources return a not-found response.

* **Tests**
  * Added coverage for authorized, unauthorized, and missing-resource scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->