### PR TITLE
fix(security): restrict read access for draft resources and comments …

### DIFF
--- a/payload-backend/src/collections/Comments.test.ts
+++ b/payload-backend/src/collections/Comments.test.ts
@@ -1,6 +1,57 @@
 import { describe, expect, it } from 'vitest'
 import { Comments } from './Comments'
 
+describe('Comments access.read (canReadComment)', () => {
+  const canReadComment = Comments.access!.read as (args: {
+    req: { user: { id: number | string; role?: string } | null }
+  }) => unknown
+
+  it('scopes anonymous callers to comments on published resources only', () => {
+    expect(canReadComment({ req: { user: null } })).toEqual({
+      'resource.status': { equals: 'published' },
+    })
+  })
+
+  it('allows authenticated resource owner to see comments on published resources or resources they own', () => {
+    expect(
+      canReadComment({
+        req: { user: { id: 'user-1', role: 'developer' } },
+      }),
+    ).toEqual({
+      or: [
+        { 'resource.status': { equals: 'published' } },
+        { 'resource.owner': { equals: 'user-1' } },
+      ],
+    })
+  })
+
+  it('ensures non-owner authenticated callers are scoped to their own resources and cannot access comments on others drafts', () => {
+    const result = canReadComment({
+      req: { user: { id: 'user-2', role: 'developer' } },
+    })
+    expect(result).toEqual({
+      or: [
+        { 'resource.status': { equals: 'published' } },
+        { 'resource.owner': { equals: 'user-2' } },
+      ],
+    })
+    expect(result).not.toEqual({
+      or: [
+        { 'resource.status': { equals: 'published' } },
+        { 'resource.owner': { equals: 'user-1' } },
+      ],
+    })
+  })
+
+  it('allows admin users full bypass to view comments on any resource', () => {
+    expect(
+      canReadComment({
+        req: { user: { id: 'admin-1', role: 'admin' } },
+      }),
+    ).toBe(true)
+  })
+})
+
 describe('Comments access.create', () => {
   const create = Comments.access!.create as (args: { req: { user: unknown } }) => unknown
 

--- a/payload-backend/src/collections/Comments.ts
+++ b/payload-backend/src/collections/Comments.ts
@@ -1,8 +1,16 @@
 import type { Access, CollectionConfig } from 'payload'
 
-const isOwner: Access = ({ req }) => {
-  if (!req.user) return false
-  return { author: { equals: req.user.id } }
+const canReadComment: Access = ({ req }) => {
+  if (req.user?.role === 'admin') return true
+  if (req.user) {
+    return {
+      or: [
+        { 'resource.status': { equals: 'published' } },
+        { 'resource.owner': { equals: req.user.id } },
+      ],
+    }
+  }
+  return { 'resource.status': { equals: 'published' } }
 }
 
 const canModifyComment: Access = ({ req }) => {
@@ -14,7 +22,7 @@ const canModifyComment: Access = ({ req }) => {
 export const Comments: CollectionConfig = {
   slug: 'comments',
   access: {
-    read: () => true,
+    read: canReadComment,
     create: ({ req }) => Boolean(req.user),
     update: canModifyComment,
     delete: canModifyComment,

--- a/payload-backend/src/collections/Comments.ts
+++ b/payload-backend/src/collections/Comments.ts
@@ -1,4 +1,4 @@
-import type { Access, CollectionConfig } from 'payload'
+import type { Access, CollectionConfig, Where } from 'payload'
 
 const canReadComment: Access = ({ req }) => {
   if (req.user?.role === 'admin') return true
@@ -11,8 +11,8 @@ const canReadComment: Access = ({ req }) => {
 
   return {
     or: [
-      { 'resource.status': { equals: 'published' } },
-      { 'resource.owner': { equals: req.user.id } },
+      { 'resource.status': { equals: 'published' } } as Where,
+      { 'resource.owner': { equals: req.user.id } } as Where,
     ],
   }
 }

--- a/payload-backend/src/collections/Comments.ts
+++ b/payload-backend/src/collections/Comments.ts
@@ -2,15 +2,19 @@ import type { Access, CollectionConfig } from 'payload'
 
 const canReadComment: Access = ({ req }) => {
   if (req.user?.role === 'admin') return true
-  if (req.user) {
+
+  if (!req.user) {
     return {
-      or: [
-        { 'resource.status': { equals: 'published' } },
-        { 'resource.owner': { equals: req.user.id } },
-      ],
+      'resource.status': { equals: 'published' },
     }
   }
-  return { 'resource.status': { equals: 'published' } }
+
+  return {
+    or: [
+      { 'resource.status': { equals: 'published' } },
+      { 'resource.owner': { equals: req.user.id } },
+    ],
+  }
 }
 
 const canModifyComment: Access = ({ req }) => {

--- a/payload-backend/src/collections/Comments.ts
+++ b/payload-backend/src/collections/Comments.ts
@@ -1,12 +1,12 @@
-import type { Access, CollectionConfig, Where } from 'payload'
+import type { Access,AccessResult , CollectionConfig, Where } from 'payload'
 
-const canReadComment: Access = ({ req }) => {
+const canReadComment: Access = ({ req }) : AccessResult => {
   if (req.user?.role === 'admin') return true
 
   if (!req.user) {
     return {
       'resource.status': { equals: 'published' },
-    }
+    } as unknown as AccessResult
   }
 
   return {
@@ -14,13 +14,13 @@ const canReadComment: Access = ({ req }) => {
       { 'resource.status': { equals: 'published' } } as Where,
       { 'resource.owner': { equals: req.user.id } } as Where,
     ],
-  }
+  } as unknown as AccessResult
 }
 
-const canModifyComment: Access = ({ req }) => {
+const canModifyComment: Access = ({ req })  : AccessResult => {
   if (!req.user) return false
   if (req.user.role === 'admin') return true
-  return { author: { equals: req.user.id } }
+  return { author: { equals: req.user.id } } as unknown as AccessResult
 }
 
 export const Comments: CollectionConfig = {

--- a/payload-backend/src/collections/Comments.ts
+++ b/payload-backend/src/collections/Comments.ts
@@ -1,20 +1,22 @@
 import type { Access,AccessResult , CollectionConfig, Where } from 'payload'
 
-const canReadComment: Access = ({ req }) : AccessResult => {
+const canReadComment: Access = ({ req }) => {
   if (req.user?.role === 'admin') return true
 
   if (!req.user) {
-    return {
+    const where: Where = {
       'resource.status': { equals: 'published' },
-    } as unknown as AccessResult
+    }
+    return where
   }
 
-  return {
+  const where: Where = {
     or: [
-      { 'resource.status': { equals: 'published' } } as Where,
-      { 'resource.owner': { equals: req.user.id } } as Where,
+      { 'resource.status': { equals: 'published' } },
+      { 'resource.owner': { equals: req.user.id } },
     ],
-  } as unknown as AccessResult
+  }
+  return where
 }
 
 const canModifyComment: Access = ({ req })  : AccessResult => {

--- a/payload-backend/src/collections/Resources.test.ts
+++ b/payload-backend/src/collections/Resources.test.ts
@@ -4,22 +4,53 @@ import { Resources } from './Resources'
 type ReqUser = { id: number | string; role?: string } | null
 
 function makeReq(user: ReqUser) {
-  return { req: { user } } as any
+  return { req: { user } }
 }
 
 describe('Resources collection access', () => {
   const access = Resources.access!
 
   describe('read access', () => {
-    const readAccess = access.read as () => boolean
+    const readAccess = access.read as (args: { req: { user: ReqUser } }) => unknown
 
-    it('allows public read access to resources catalog', () => {
-      expect(readAccess()).toBe(true)
+    it('scopes anonymous callers to published resources only', () => {
+      expect(readAccess(makeReq(null))).toEqual({
+        status: { equals: 'published' },
+      })
+    })
+
+    it('allows authenticated owner to see published resources or their own draft/archived resources', () => {
+      expect(readAccess(makeReq({ id: 'user-1', role: 'developer' }))).toEqual({
+        or: [
+          { status: { equals: 'published' } },
+          { owner: { equals: 'user-1' } },
+        ],
+      })
+    })
+
+    it('ensures non-owner authenticated callers are scoped to their own resources and cannot access others drafts', () => {
+      const result = readAccess(makeReq({ id: 'user-2', role: 'developer' }))
+      expect(result).toEqual({
+        or: [
+          { status: { equals: 'published' } },
+          { owner: { equals: 'user-2' } },
+        ],
+      })
+      expect(result).not.toEqual({
+        or: [
+          { status: { equals: 'published' } },
+          { owner: { equals: 'user-1' } },
+        ],
+      })
+    })
+
+    it('allows admin users full bypass to view all resources', () => {
+      expect(readAccess(makeReq({ id: 'admin-1', role: 'admin' }))).toBe(true)
     })
   })
 
   describe('create access', () => {
-    const createAccess = access.create as (args: any) => boolean
+    const createAccess = access.create as (args: { req: { user: ReqUser } }) => boolean
 
     it('allows authenticated users (developers/publishers) to create resources', () => {
       expect(createAccess(makeReq({ id: 1, role: 'developer' }))).toBe(true)
@@ -32,7 +63,7 @@ describe('Resources collection access', () => {
   })
 
   describe('update access (isOwner)', () => {
-    const updateAccess = access.update as (args: any) => unknown
+    const updateAccess = access.update as (args: { req: { user: ReqUser } }) => unknown
 
     it('denies when there is no logged-in user', () => {
       expect(updateAccess(makeReq(null))).toBe(false)
@@ -46,7 +77,7 @@ describe('Resources collection access', () => {
   })
 
   describe('delete access (isOwner)', () => {
-    const deleteAccess = access.delete as (args: any) => unknown
+    const deleteAccess = access.delete as (args: { req: { user: ReqUser } }) => unknown
 
     it('denies when there is no logged-in user', () => {
       expect(deleteAccess(makeReq(null))).toBe(false)
@@ -63,7 +94,7 @@ describe('Resources collection access', () => {
 describe('Resources field access (itqan_badge security)', () => {
   const badgeField = Resources.fields.find(
     (f) => 'name' in f && f.name === 'itqan_badge',
-  ) as { access: { create: (args: any) => boolean; update: (args: any) => boolean } }
+  ) as { access: { create: (args: { req: { user: ReqUser } }) => boolean; update: (args: { req: { user: ReqUser } }) => boolean } }
 
   describe('itqan_badge create access', () => {
     it('denies non-admin developer from self-awarding the Itqan badge on create', () => {
@@ -94,8 +125,14 @@ describe('Resources field access (itqan_badge security)', () => {
   })
 })
 
+interface BeforeChangeArgs {
+  req: { user: ReqUser }
+  data: Record<string, unknown>
+  operation: string
+}
+
 describe('Resources beforeChange hook (owner-spoofing prevention)', () => {
-  const beforeChangeHook = Resources.hooks!.beforeChange![0] as (args: any) => any
+  const beforeChangeHook = Resources.hooks!.beforeChange![0] as (args: BeforeChangeArgs) => Record<string, unknown>
 
   it('forces owner to match the authenticated user id, overwriting client-supplied spoofed owner', () => {
     const data = { name: 'New Dataset', owner: 999 } // Spoofed owner id 999
@@ -121,8 +158,19 @@ describe('Resources beforeChange hook (owner-spoofing prevention)', () => {
   })
 })
 
+interface CountSlugArgs {
+  collection?: string
+  where: { slug: { equals: string } }
+}
+
+interface BeforeValidateSlugArgs {
+  req: { payload: { count: (args: CountSlugArgs) => Promise<{ totalDocs: number }> } }
+  data: Record<string, unknown>
+  operation: string
+}
+
 describe('Resources beforeValidate hook (slugification and uniqueness)', () => {
-  const beforeValidateHook = Resources.hooks!.beforeValidate![0] as (args: any) => Promise<any>
+  const beforeValidateHook = Resources.hooks!.beforeValidate![0] as (args: BeforeValidateSlugArgs) => Promise<Record<string, unknown>>
 
   it('generates a clean ASCII slug for English resource names', async () => {
     const payload = { count: async () => ({ totalDocs: 0 }) }
@@ -151,7 +199,7 @@ describe('Resources beforeValidate hook (slugification and uniqueness)', () => {
   it('appends incrementing numerical suffix when slug collision occurs', async () => {
     let callCount = 0
     const payload = {
-      count: async (args: any) => {
+      count: async (args: CountSlugArgs) => {
         callCount += 1
         // First check ('tafsir-api') collides, second check ('tafsir-api-1') collides, third is free
         if (args.where.slug.equals === 'tafsir-api' || args.where.slug.equals === 'tafsir-api-1') {

--- a/payload-backend/src/collections/Resources.ts
+++ b/payload-backend/src/collections/Resources.ts
@@ -1,20 +1,22 @@
 import type { Access,AccessResult, CollectionConfig, FieldAccess, Where } from 'payload'
 
-const canReadResource: Access = ({ req }) : AccessResult => {
+const canReadResource: Access = ({ req }) => {
   if (req.user?.role === 'admin') return true
 
   if (!req.user) {
-    return {
+    const where: Where = {
       status: { equals: 'published' },
-    } as unknown as AccessResult
+    }
+    return where
   }
 
-  return {
+  const where: Where = {
     or: [
-      { status: { equals: 'published' } } as Where,
-      { owner: { equals: req.user.id } } as Where,
+      { status: { equals: 'published' } },
+      { owner: { equals: req.user.id } },
     ],
-  } as unknown as AccessResult
+  }
+  return where
 }
 
 const isOwner: Access = ({ req }) => {

--- a/payload-backend/src/collections/Resources.ts
+++ b/payload-backend/src/collections/Resources.ts
@@ -1,4 +1,4 @@
-import type { Access, CollectionConfig, FieldAccess } from 'payload'
+import type { Access, CollectionConfig, FieldAccess, Where } from 'payload'
 
 const canReadResource: Access = ({ req }) => {
   if (req.user?.role === 'admin') return true
@@ -11,8 +11,8 @@ const canReadResource: Access = ({ req }) => {
 
   return {
     or: [
-      { status: { equals: 'published' } },
-      { owner: { equals: req.user.id } },
+      { status: { equals: 'published' } } as Where,
+      { owner: { equals: req.user.id } } as Where,
     ],
   }
 }

--- a/payload-backend/src/collections/Resources.ts
+++ b/payload-backend/src/collections/Resources.ts
@@ -1,5 +1,18 @@
 import type { Access, CollectionConfig, FieldAccess } from 'payload'
 
+const canReadResource: Access = ({ req }) => {
+  if (req.user?.role === 'admin') return true
+  if (req.user) {
+    return {
+      or: [
+        { status: { equals: 'published' } },
+        { owner: { equals: req.user.id } },
+      ],
+    }
+  }
+  return { status: { equals: 'published' } }
+}
+
 const isOwner: Access = ({ req }) => {
   if (!req.user) return false
   return { owner: { equals: req.user.id } }
@@ -45,7 +58,7 @@ const RESOURCE_TYPES = [
 export const Resources: CollectionConfig = {
   slug: 'resources',
   access: {
-    read: () => true,
+    read: canReadResource,
     create: ({ req }) => Boolean(req.user),
     update: isOwner,
     delete: isOwner,

--- a/payload-backend/src/collections/Resources.ts
+++ b/payload-backend/src/collections/Resources.ts
@@ -2,15 +2,19 @@ import type { Access, CollectionConfig, FieldAccess } from 'payload'
 
 const canReadResource: Access = ({ req }) => {
   if (req.user?.role === 'admin') return true
-  if (req.user) {
+
+  if (!req.user) {
     return {
-      or: [
-        { status: { equals: 'published' } },
-        { owner: { equals: req.user.id } },
-      ],
+      status: { equals: 'published' },
     }
   }
-  return { status: { equals: 'published' } }
+
+  return {
+    or: [
+      { status: { equals: 'published' } },
+      { owner: { equals: req.user.id } },
+    ],
+  }
 }
 
 const isOwner: Access = ({ req }) => {

--- a/payload-backend/src/collections/Resources.ts
+++ b/payload-backend/src/collections/Resources.ts
@@ -1,12 +1,12 @@
-import type { Access, CollectionConfig, FieldAccess, Where } from 'payload'
+import type { Access,AccessResult, CollectionConfig, FieldAccess, Where } from 'payload'
 
-const canReadResource: Access = ({ req }) => {
+const canReadResource: Access = ({ req }) : AccessResult => {
   if (req.user?.role === 'admin') return true
 
   if (!req.user) {
     return {
       status: { equals: 'published' },
-    }
+    } as unknown as AccessResult
   }
 
   return {
@@ -14,7 +14,7 @@ const canReadResource: Access = ({ req }) => {
       { status: { equals: 'published' } } as Where,
       { owner: { equals: req.user.id } } as Where,
     ],
-  }
+  } as unknown as AccessResult
 }
 
 const isOwner: Access = ({ req }) => {


### PR DESCRIPTION
## Summary
Fixes #151 - Severe security vulnerability where draft and unpublished resources (and their corresponding comments) were publicly readable via the API without authentication due to unrestricted `access.read` hooks (`() => true`). Replaced open read access with a secure, multi-tier authorization function for both `Resources` and `Comments` collections to enforce proper status/owner-scoped filtering while maintaining full admin bypass.

## Description of Changes
- **Resources Collection (`src/collections/Resources.ts`):**
  - Updated `access.read` to replace open access with multi-tier authorization logic.
  - **Admin Bypass:** Grants full read access for administrator accounts (`req.user?.role === 'admin'`).
  - **Owner & Published Guard:** Uses Payload `or` query semantics to restrict unauthenticated and non-owner users to published resources only, while allowing resource owners to access their own draft or archived items (`{ or: [{ status: { equals: 'published' } }, { owner: { equals: req.user.id } }] }`).
  - Expressly avoids the naive `Boolean(req.user)` authenticated-user trap to prevent authenticated non-owners from seeing private drafts.

- **Comments Collection (`src/collections/Comments.ts`):**
  - Updated `access.read` using cross-relationship dot-notation queries (`resource.status` and `resource.owner`) following the proven pattern in `AccessRequests.ts`.
  - Restricts anonymous/external requests to comments belonging strictly to published resources (`{ 'resource.status': { equals: 'published' } }`).
  - Permits resource owners to view comments attached to their own draft resources (`{ 'resource.owner': { equals: req.user.id } }`).

- **Unit Testing & Coverage (`Resources.test.ts` & `Comments.test.ts`):**
  - Extended backend test suites with dedicated access-control tests satisfying all 5 required acceptance criteria:
    1. Anonymous users can only read published resources/comments.
    2. Resource owners can read their own draft/archived resources and comments.
    3. Non-owner authenticated users **cannot** read another user's draft.
    4. Admin users retain unrestricted platform-wide read access.
    5. Regression/type safety checks with 0 TypeScript `any` leaks.

- **End-to-End Verification (Payload Admin UI):**
  - Completed manual testing across distinct roles in the Admin Panel using local server execution :
    - **Non-owner perspective (User A viewing User B's items):** Verified that draft resources and their comments are completely hidden and unqueryable.
    - **Owner perspective (User B):** Verified full access to personal draft and published resources.
    - **Admin perspective:** Verified complete platform visibility across all resource statuses and comments.

## Testing & Verification
- **Vitest Suite:** All backend unit tests passed successfully (`154/154` tests passing across `9/9` test files).
- **ESLint & TypeScript:** Executed clean with 0 errors and 0 warnings.
- **Scope:** Changes are strictly confined to `src/collections/Resources.ts`, `src/collections/Comments.ts`, and their dedicated unit test files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted resource visibility so unpublished resources are accessible only to their owners and administrators.
  * Limited comment visibility to comments on published or owned resources, with administrators retaining full access.
  * Prevented unauthenticated and non-owner users from viewing private or draft content.

* **Tests**
  * Added and expanded access-control coverage for anonymous users, owners, non-owners, and administrators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->