### PR TITLE
fix(register): enforce 8-64 character passwords on register

### DIFF
--- a/payload-backend/src/collections/Users.ts
+++ b/payload-backend/src/collections/Users.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig, FieldAccess } from 'payload'
+import { passwordValidation } from './hooks/validate-password'
 
 // Mirrors the itqan_badge pattern in Resources.ts - role is a privilege
 // escalation vector, not self-declared metadata, so only an existing admin
@@ -12,6 +13,9 @@ export const Users: CollectionConfig = {
     useAsTitle: 'email',
   },
   auth: true,
+  hooks: {
+    beforeValidate: [passwordValidation],
+  },
   access: {
     // Public self-registration (no default access config would otherwise
     // require an authenticated user even to create an account).

--- a/payload-backend/src/collections/hooks/validate-password.test.ts
+++ b/payload-backend/src/collections/hooks/validate-password.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { APIError } from 'payload'
+import { passwordValidation } from './validate-password'
+
+async function runHook(data: Record<string, unknown> | undefined) {
+  return passwordValidation({ data } as Parameters<typeof passwordValidation>[0])
+}
+
+describe('passwordValidation', () => {
+  it('returns without throwing when no data is provided', async () => {
+    await expect(runHook(undefined)).resolves.toBeUndefined()
+  })
+
+  it('rejects a missing password', async () => {
+    await expect(runHook({ email: 'dev@example.com' })).rejects.toMatchObject({
+      message: 'Password is required',
+      status: 422,
+    })
+    await expect(runHook({ email: 'dev@example.com' })).rejects.toBeInstanceOf(APIError)
+  })
+
+  it('rejects a password shorter than 8 characters', async () => {
+    await expect(runHook({ password: 'short' })).rejects.toMatchObject({
+      message: 'Password must be at least 8 characters long',
+      status: 422,
+    })
+  })
+
+  it('rejects a password longer than 64 characters', async () => {
+    await expect(runHook({ password: 'a'.repeat(65) })).rejects.toMatchObject({
+      message: 'Password must be less than 64 characters long',
+      status: 422,
+    })
+  })
+
+  it('returns the data when the password is between 8 and 64 characters', async () => {
+    const data = { password: 'validpass', email: 'dev@example.com' }
+    await expect(runHook(data)).resolves.toEqual(data)
+  })
+})

--- a/payload-backend/src/collections/hooks/validate-password.test.ts
+++ b/payload-backend/src/collections/hooks/validate-password.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 import { APIError } from 'payload'
 import { passwordValidation } from './validate-password'
 
+const lengthError = 'Password must be between 8 and 64 characters long'
+
 async function runHook(data: Record<string, unknown> | undefined) {
   return passwordValidation({ data } as Parameters<typeof passwordValidation>[0])
 }
@@ -11,24 +13,29 @@ describe('passwordValidation', () => {
     await expect(runHook(undefined)).resolves.toBeUndefined()
   })
 
-  it('rejects a missing password', async () => {
-    await expect(runHook({ email: 'dev@example.com' })).rejects.toMatchObject({
-      message: 'Password is required',
+  it('allows an update with no password field', async () => {
+    const data = { email: 'dev@example.com' }
+    await expect(runHook(data)).resolves.toEqual(data)
+  })
+
+  it('rejects an empty password string', async () => {
+    await expect(runHook({ password: '' })).rejects.toMatchObject({
+      message: lengthError,
       status: 422,
     })
-    await expect(runHook({ email: 'dev@example.com' })).rejects.toBeInstanceOf(APIError)
+    await expect(runHook({ password: '' })).rejects.toBeInstanceOf(APIError)
   })
 
   it('rejects a password shorter than 8 characters', async () => {
     await expect(runHook({ password: 'short' })).rejects.toMatchObject({
-      message: 'Password must be at least 8 characters long',
+      message: lengthError,
       status: 422,
     })
   })
 
   it('rejects a password longer than 64 characters', async () => {
     await expect(runHook({ password: 'a'.repeat(65) })).rejects.toMatchObject({
-      message: 'Password must be less than 64 characters long',
+      message: lengthError,
       status: 422,
     })
   })

--- a/payload-backend/src/collections/hooks/validate-password.ts
+++ b/payload-backend/src/collections/hooks/validate-password.ts
@@ -4,15 +4,12 @@ export const passwordValidation: CollectionBeforeValidateHook<TypedUser> = async
     // Ignore if no data is provided
     if (!data) return;
     
-    if (!data.password) {
-        throw new APIError('Password is required', 422);
+    if (data.password === undefined || data.password === null) {
+        return data; // profile update, no password change
     }
 
-    if (data.password.length < 8) {
-        throw new APIError('Password must be at least 8 characters long', 422);
-    }
-    if (data.password.length > 64) {
-        throw new APIError('Password must be less than 64 characters long', 422);
+    if (typeof data.password !== 'string' || data.password.length < 8 || data.password.length > 64) {
+        throw new APIError("Password must be between 8 and 64 characters long", 422);
     }
     return data;
 }

--- a/payload-backend/src/collections/hooks/validate-password.ts
+++ b/payload-backend/src/collections/hooks/validate-password.ts
@@ -1,0 +1,18 @@
+import { APIError, TypedUser, type CollectionBeforeValidateHook } from 'payload'
+
+export const passwordValidation: CollectionBeforeValidateHook<TypedUser> = async ({data}) => {
+    // Ignore if no data is provided
+    if (!data) return;
+    
+    if (!data.password) {
+        throw new APIError('Password is required', 422);
+    }
+
+    if (data.password.length < 8) {
+        throw new APIError('Password must be at least 8 characters long', 422);
+    }
+    if (data.password.length > 64) {
+        throw new APIError('Password must be less than 64 characters long', 422);
+    }
+    return data;
+}

--- a/src/__tests__/RegisterForm.test.tsx
+++ b/src/__tests__/RegisterForm.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { RegisterForm } from '@/modules/auth/components/RegisterForm';
+import { useAuth } from '@/hooks/useAuth';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('@/shared/ui/i18n', () => ({
+  useLanguage: () => ({
+    t: {
+      auth: {
+        displayName: 'Display name',
+        displayNamePlaceholder: 'Your name',
+        email: 'Email',
+        password: 'Password',
+        accountRole: 'I am joining as',
+        developer: 'Developer',
+        developerDescription: 'Build with Quranic resources',
+        publisher: 'Publisher',
+        publisherDescription: 'Share and manage resources',
+        createAccount: 'Create account',
+        creatingAccount: 'Creating account...',
+        passwordLength: 'Password must be between 8 and 64 characters.',
+      },
+    },
+  }),
+}));
+
+function fillRegisterForm(password: string) {
+  fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Test Dev' } });
+  fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'dev@example.com' } });
+  fireEvent.change(screen.getByLabelText('Password'), { target: { value: password } });
+}
+
+describe('RegisterForm', () => {
+  const register = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useAuth).mockReturnValue({
+      user: null,
+      loading: false,
+      error: null,
+      login: vi.fn(),
+      loginWithToken: vi.fn(),
+      register,
+      forgotPassword: vi.fn(),
+      resetPassword: vi.fn(),
+      verifyEmail: vi.fn(),
+      logout: vi.fn(),
+    });
+  });
+
+  it('shows a length error and does not call register when the password is too short', () => {
+    render(<RegisterForm />);
+    fillRegisterForm('short');
+    fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+
+    expect(screen.getByText('Password must be between 8 and 64 characters.')).toBeInTheDocument();
+    expect(register).not.toHaveBeenCalled();
+  });
+
+  it('shows a length error and does not call register when the password is too long', () => {
+    render(<RegisterForm />);
+    fillRegisterForm('a'.repeat(65));
+    fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+
+    expect(screen.getByText('Password must be between 8 and 64 characters.')).toBeInTheDocument();
+    expect(register).not.toHaveBeenCalled();
+  });
+
+  it('calls register when the password is valid', async () => {
+    register.mockResolvedValue({ success: true });
+    render(<RegisterForm />);
+    fillRegisterForm('validpass');
+    fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+
+    await waitFor(() => {
+      expect(register).toHaveBeenCalledWith('dev@example.com', 'validpass', 'Test Dev', 'developer');
+    });
+  });
+});

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { validatePassword } from '@/shared/utils/utils';
+
+describe('validatePassword', () => {
+  it('rejects passwords shorter than 8 characters', () => {
+    expect(validatePassword('')).toBe(false);
+    expect(validatePassword('short')).toBe(false);
+    expect(validatePassword('1234567')).toBe(false);
+  });
+
+  it('rejects passwords longer than 64 characters', () => {
+    expect(validatePassword('a'.repeat(65))).toBe(false);
+  });
+
+  it('accepts passwords between 8 and 64 characters', () => {
+    expect(validatePassword('12345678')).toBe(true);
+    expect(validatePassword('validpass')).toBe(true);
+    expect(validatePassword('a'.repeat(64))).toBe(true);
+  });
+});

--- a/src/modules/auth/components/RegisterForm.tsx
+++ b/src/modules/auth/components/RegisterForm.tsx
@@ -11,7 +11,7 @@ export function RegisterForm() {
   const [password, setPassword] = useState('');
   const [displayName, setDisplayName] = useState('');
   const [role, setRole] = useState<'developer' | 'publisher'>('developer');
-  const { register, error } = useAuth();
+  const { register } = useAuth();
   const [submitting, setSubmitting] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
   const { t } = useLanguage();
@@ -26,6 +26,7 @@ export function RegisterForm() {
       return;
     }
 
+    setFormError(null);
     setSubmitting(true);
     try {
       const result = await register(email, password, displayName, role);

--- a/src/modules/auth/components/RegisterForm.tsx
+++ b/src/modules/auth/components/RegisterForm.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/hooks/useAuth';
 import { useLanguage } from '@/shared/ui/i18n';
+import { validatePassword } from '@/shared/utils/utils';
 
 export function RegisterForm() {
   const [email, setEmail] = useState('');
@@ -11,22 +12,31 @@ export function RegisterForm() {
   const [displayName, setDisplayName] = useState('');
   const [role, setRole] = useState<'developer' | 'publisher'>('developer');
   const { register, loading, error } = useAuth();
+  const [formError, setFormError] = useState<string | null>(null);
   const { t } = useLanguage();
   const router = useRouter();
   const copy = t.auth;
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
+
+    if (!validatePassword(password)){
+      setFormError(copy.passwordLength);
+      return
+    }
+
     const result = await register(email, password, displayName, role);
     if (result.success) {
       router.push('/dashboard');
       router.refresh();
+    }else{
+      setFormError(result.error ?? null);
     }
   };
 
   return (
     <form onSubmit={handleSubmit} className="space-y-5">
-      {error && <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm leading-6 text-red-700">{error}</div>}
+      {formError && <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm leading-6 text-red-700">{formError}</div>}
 
       <div>
         <label htmlFor="reg-name" className="mb-2 block text-sm font-black text-[#3f4851]">{copy.displayName}</label>

--- a/src/modules/auth/components/RegisterForm.tsx
+++ b/src/modules/auth/components/RegisterForm.tsx
@@ -11,7 +11,8 @@ export function RegisterForm() {
   const [password, setPassword] = useState('');
   const [displayName, setDisplayName] = useState('');
   const [role, setRole] = useState<'developer' | 'publisher'>('developer');
-  const { register, loading, error } = useAuth();
+  const { register, error } = useAuth();
+  const [submitting, setSubmitting] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
   const { t } = useLanguage();
   const router = useRouter();
@@ -20,17 +21,22 @@ export function RegisterForm() {
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
 
-    if (!validatePassword(password)){
+    if (!validatePassword(password)) {
       setFormError(copy.passwordLength);
-      return
+      return;
     }
 
-    const result = await register(email, password, displayName, role);
-    if (result.success) {
-      router.push('/dashboard');
-      router.refresh();
-    }else{
-      setFormError(result.error ?? null);
+    setSubmitting(true);
+    try {
+      const result = await register(email, password, displayName, role);
+      if (result.success) {
+        router.push('/dashboard');
+        router.refresh();
+      } else {
+        setFormError(result.error ?? null);
+      }
+    } finally {
+      setSubmitting(false);
     }
   };
 
@@ -49,8 +55,22 @@ export function RegisterForm() {
           <input id="reg-email" type="email" value={email} onChange={(event) => setEmail(event.target.value)} className="input-field h-12 rounded-lg" required placeholder="you@example.com" dir="ltr" />
         </div>
         <div>
-          <label htmlFor="reg-password" className="mb-2 block text-sm font-black text-[#3f4851]">{copy.password}</label>
-          <input id="reg-password" type="password" value={password} onChange={(event) => setPassword(event.target.value)} className="input-field h-12 rounded-lg" required placeholder="********" dir="ltr" />
+          <label
+            htmlFor="reg-password"
+            className="mb-2 block text-sm font-black text-[#3f4851]"
+          >
+            {copy.password}
+          </label>
+          <input
+            id="reg-password"
+            type="password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            className="input-field h-12 rounded-lg"
+            required
+            placeholder="********"
+            dir="ltr"
+          />
         </div>
       </div>
 
@@ -74,8 +94,12 @@ export function RegisterForm() {
         </div>
       </fieldset>
 
-      <button type="submit" disabled={loading} className="flex h-12 w-full items-center justify-center rounded-full bg-black px-5 text-sm font-black text-white transition hover:bg-[#171717] disabled:cursor-not-allowed disabled:opacity-60">
-        {loading ? copy.creatingAccount : copy.createAccount}
+      <button
+        type="submit"
+        disabled={submitting}
+        className="flex h-12 w-full items-center justify-center rounded-full bg-black px-5 text-sm font-black text-white transition hover:bg-[#171717] disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {submitting ? copy.creatingAccount : copy.createAccount}
       </button>
     </form>
   );

--- a/src/modules/auth/components/ResetPasswordForm.tsx
+++ b/src/modules/auth/components/ResetPasswordForm.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useAuth } from "@/hooks/useAuth";
 import { useLanguage } from "@/shared/ui/i18n";
 import Image from "next/image";
+import { validatePassword } from "@/shared/utils/utils";
 
 export function ResetPasswordForm({ token }: { token: string }) {
   const { t } = useLanguage();
@@ -19,7 +20,9 @@ export function ResetPasswordForm({ token }: { token: string }) {
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (password.length < 8 || password.length > 64) {
+    
+    // Validate password
+    if (!validatePassword(password)) {
       setFormError(copy.passwordLength);
       return;
     }

--- a/src/shared/utils/utils.ts
+++ b/src/shared/utils/utils.ts
@@ -15,3 +15,15 @@ export function formatDate(dateString: string, locale: 'ar' | 'en' = 'ar'): stri
     day: 'numeric',
   });
 }
+
+const PASSWORD_MIN_LENGTH = 8;
+const PASSWORD_MAX_LENGTH = 64;
+export function validatePassword(password: string): boolean {
+  if (password.length < PASSWORD_MIN_LENGTH) {
+    return false;
+  }
+  if (password.length > PASSWORD_MAX_LENGTH) {
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary
- Register uses the same 8–64 password length check as reset (`validatePassword`).
- Users `beforeValidate` enforces the same range on the API so the check can’t be skipped.
- Updates with no `password` field are skipped so existing accounts / profile edits stay valid.

Closes https://github.com/Itqan-community/RATQ/issues/255

<img width="738" height="878" alt="image" src="https://github.com/user-attachments/assets/975c5f8a-e910-4047-9a8c-11f7960e9e4b" />

## Test plan
- [ ] Register with password length < 8 or > 64 → clear error, no request
- [ ] Register with 8–64 characters → succeeds (or Payload error if email verify blocks login)
- [ ] `POST /api/users` with a too-short password → 422
- [ ] Update a user without sending `password` → still works