### PR TITLE
Feat/toast bug

### DIFF
--- a/src/__tests__/ReportModal.test.tsx
+++ b/src/__tests__/ReportModal.test.tsx
@@ -1,38 +1,49 @@
-import { act } from 'react';
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
-import { ReportModal } from '@/modules/resources/components/ReportModal';
-import { LanguageProvider } from '@/shared/ui/i18n/LanguageContext';
+import { act } from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ReportModal } from "@/modules/resources/components/ReportModal";
+import { LanguageProvider } from "@/shared/ui/i18n/LanguageContext";
+import { ToastProvider } from "@/shared/ui/Toast";
 
-function renderModal(locale: 'ar' | 'en') {
-  localStorage.setItem('ratq_locale', locale);
+function renderModal(locale: "ar" | "en") {
+  localStorage.setItem("ratq_locale", locale);
 
   render(
     <LanguageProvider>
-      <ReportModal
-        isOpen
-        onClose={() => {}}
-        resourceId={1}
-        resourceName="Test resource"
-      />
+      <ToastProvider>
+        <ReportModal
+          isOpen
+          onClose={() => {}}
+          resourceId={1}
+          resourceName="Test resource"
+        />
+      </ToastProvider>
     </LanguageProvider>,
   );
 
   act(() => {});
 }
 
-describe('ReportModal', () => {
-  it('renders the report placeholders in Arabic', () => {
-    renderModal('ar');
+describe("ReportModal", () => {
+  it("renders the report placeholders in Arabic", () => {
+    renderModal("ar");
 
-    expect(screen.getByRole('option', { name: 'اختر سببا' })).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('قدم تفاصيل إضافية...')).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "اختر سببا" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("قدم تفاصيل إضافية..."),
+    ).toBeInTheDocument();
   });
 
-  it('renders the report placeholders in English', () => {
-    renderModal('en');
+  it("renders the report placeholders in English", () => {
+    renderModal("en");
 
-    expect(screen.getByRole('option', { name: 'Select a reason' })).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('Provide additional context...')).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "Select a reason" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Provide additional context..."),
+    ).toBeInTheDocument();
   });
 });

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,29 +1,30 @@
-import type { Metadata } from 'next';
-import { IBM_Plex_Sans_Arabic } from 'next/font/google';
-import { Header } from '@/shared/ui/layout/Header';
-import { Footer } from '@/shared/ui/layout/Footer';
-import { LanguageProvider } from '@/shared/ui/i18n';
-import { AuthProvider } from '@/hooks/useAuth';
-import '@/styles/globals.css';
+import type { Metadata } from "next";
+import { IBM_Plex_Sans_Arabic } from "next/font/google";
+import { Header } from "@/shared/ui/layout/Header";
+import { Footer } from "@/shared/ui/layout/Footer";
+import { LanguageProvider } from "@/shared/ui/i18n";
+import { AuthProvider } from "@/hooks/useAuth";
+import "@/styles/globals.css";
+import { ToastProvider } from "@/shared/ui/Toast";
 
 const plexSansArabic = IBM_Plex_Sans_Arabic({
-  variable: '--font-plex-sans-arabic',
-  subsets: ['latin', 'arabic'],
-  weight: ['400', '500', '600', '700'],
-  display: 'swap',
+  variable: "--font-plex-sans-arabic",
+  subsets: ["latin", "arabic"],
+  weight: ["400", "500", "600", "700"],
+  display: "swap",
 });
 
 export const metadata: Metadata = {
   title: {
-    default: 'RATQ — Community Platform',
-    template: '%s | RATQ Community Platform',
+    default: "RATQ — Community Platform",
+    template: "%s | RATQ Community Platform",
   },
   description:
-    'A community-driven hub for discovering, distributing, and governing Quranic development assets. Libraries, SDKs, datasets, APIs, and scholarly resources.',
+    "A community-driven hub for discovering, distributing, and governing Quranic development assets. Libraries, SDKs, datasets, APIs, and scholarly resources.",
   icons: {
-    icon: '/images/logo.png',
-    shortcut: '/images/logo.png',
-    apple: '/images/logo.png',
+    icon: "/images/logo.png",
+    shortcut: "/images/logo.png",
+    apple: "/images/logo.png",
   },
 };
 
@@ -34,17 +35,19 @@ export default function RootLayout({
 }) {
   return (
     <html
-      lang='ar'
-      dir='rtl'
+      lang="ar"
+      dir="rtl"
       className={plexSansArabic.variable}
-      data-scroll-behavior='smooth'
+      data-scroll-behavior="smooth"
     >
-      <body className='min-h-screen flex flex-col bg-[var(--bg-primary)]'>
+      <body className="min-h-screen flex flex-col bg-[var(--bg-primary)]">
         <LanguageProvider>
           <AuthProvider>
-            <Header />
-            <main className='flex-grow'>{children}</main>
-            <Footer />
+            <ToastProvider>
+              <Header />
+              <main className="flex-grow">{children}</main>
+              <Footer />
+            </ToastProvider>
           </AuthProvider>
         </LanguageProvider>
       </body>

--- a/src/shared/ui/Toast.tsx
+++ b/src/shared/ui/Toast.tsx
@@ -1,8 +1,14 @@
-'use client';
+"use client";
 
-import { useState, useEffect, useCallback } from 'react';
+import {
+  useState,
+  useCallback,
+  createContext,
+  useContext,
+  ReactNode,
+} from "react";
 
-type ToastType = 'success' | 'error' | 'info';
+type ToastType = "success" | "error" | "info";
 
 interface ToastData {
   id: number;
@@ -12,10 +18,16 @@ interface ToastData {
 
 let toastId = 0;
 
-export function useToast() {
+type ToastContextType = {
+  toast: (message: string, type?: ToastType) => void;
+};
+
+const ToastContext = createContext<ToastContextType | null>(null);
+
+export function ToastProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<ToastData[]>([]);
 
-  const toast = useCallback((message: string, type: ToastType = 'info') => {
+  const toast = useCallback((message: string, type: ToastType = "info") => {
     const id = ++toastId;
     setToasts((prev) => [...prev, { id, message, type }]);
     setTimeout(() => {
@@ -27,14 +39,35 @@ export function useToast() {
     setToasts((prev) => prev.filter((t) => t.id !== id));
   }, []);
 
-  return { toast, toasts, removeToast };
+  return (
+    <ToastContext.Provider value={{ toast }}>
+      {children}
+      <ToastContainer toasts={toasts} removeToast={removeToast} />
+    </ToastContext.Provider>
+  );
 }
 
-export function ToastContainer({ toasts, removeToast }: { toasts: ToastData[]; removeToast: (id: number) => void }) {
+export function useToast() {
+  const context = useContext(ToastContext);
+
+  if (!context) {
+    throw new Error("useToast must be used within a ToastProvider");
+  }
+
+  return context;
+}
+
+export function ToastContainer({
+  toasts,
+  removeToast,
+}: {
+  toasts: ToastData[];
+  removeToast: (id: number) => void;
+}) {
   const styles: Record<ToastType, string> = {
-    success: 'bg-green-50 border-green-200 text-green-800',
-    error: 'bg-red-50 border-red-200 text-red-800',
-    info: 'bg-blue-50 border-blue-200 text-blue-800',
+    success: "bg-green-50 border-green-200 text-green-800",
+    error: "bg-red-50 border-red-200 text-red-800",
+    info: "bg-blue-50 border-blue-200 text-blue-800",
   };
 
   return (


### PR DESCRIPTION
## Summary
Solved the issue of toast messages not being displayed on the screen by using a shared context: `ToastContext`. The `ToastProvider` is used in the root layout, so all toast messages are shared between the app's components. This closes issue #262.

## Changes

- Created a `ToastContext` and `ToastProvider` in `src/shared/ui/Toast.tsx`. I tried to match the existing architecture used in the project, like `LanguageContext` and `AuthContext`.
- `ToastProvider` is mounted once in the root layout, which also ensures that `ToastContainer` is rendered only once, as required.
- Updated `useToast` to consume `ToastContext` and handle the null-context case. Existing usage in `ReportModal` did not need to change.
- Updated `ReportModal.test.tsx` to wrap the component with `ToastProvider`, preventing null-context errors during tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated toast notifications to use a shared application-wide provider.
  * Toast messages are now rendered consistently across the header, main content, and footer.

* **Tests**
  * Updated report modal tests to support the shared toast notification system.
  * Preserved English and Arabic placeholder coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->