### PR TITLE
ci: serialize backend deploy jobs

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -36,6 +36,7 @@ jobs:
     concurrency:
       group: deploy-backend
       cancel-in-progress: false
+      queue: max
     runs-on: ubuntu-latest
     steps:
       - name: Deploy to droplet

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -33,6 +33,9 @@ jobs:
   deploy:
     needs: test
     if: github.event_name == 'push'
+    concurrency:
+      group: deploy-backend
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     steps:
       - name: Deploy to droplet


### PR DESCRIPTION
Fixes #271

## Summary

Adds a concurrency guard to the backend deploy job to prevent simultaneous deployments to the same droplet.

## Changes

- Add job-level concurrency to the `deploy` job
- Use the same `deploy-backend` concurrency group for `main` and `beta`
- Set `cancel-in-progress: false` so an active deployment is not cancelled

## Why

Pushes to `main` and `beta` can occur nearly simultaneously during the normal main → beta sync. Both runs target the same droplet, which can cause a race during Docker container recreation.

Serializing the deploy job prevents this race while still allowing test jobs to run concurrently.

## Validation

- `git diff --check` passes
- Workflow structure reviewed
- Deployment triggers and scripts remain unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backend deployment reliability by ensuring deployments run one at a time.
  * Queued deployments are now preserved instead of being canceled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->