### PR TITLE
fix(toast): respect active language direction in ToastContainer

### DIFF
--- a/src/__tests__/Toast.test.tsx
+++ b/src/__tests__/Toast.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { render, act } from "@testing-library/react";
+import { ToastContainer } from "@/shared/ui/Toast";
+import { LanguageProvider } from "@/shared/ui/i18n/LanguageContext";
+
+function renderContainer(locale: "ar" | "en") {
+  localStorage.setItem("ratq_locale", locale);
+  const result = render(
+    <LanguageProvider>
+      <ToastContainer
+        toasts={[{ id: 1, message: "hello", type: "info" }]}
+        removeToast={() => {}}
+      />
+    </LanguageProvider>,
+  );
+  act(() => {});
+  return result.container.querySelector("div[dir]") as HTMLElement;
+}
+
+describe("ToastContainer", () => {
+  it("renders right-aligned with dir=rtl in Arabic", () => {
+    const el = renderContainer("ar");
+    expect(el.getAttribute("dir")).toBe("rtl");
+    expect(el.className).toContain("right-4");
+    expect(el.className).not.toContain("left-4");
+  });
+
+  it("renders left-aligned with dir=ltr in English", () => {
+    const el = renderContainer("en");
+    expect(el.getAttribute("dir")).toBe("ltr");
+    expect(el.className).toContain("left-4");
+    expect(el.className).not.toContain("right-4");
+  });
+});

--- a/src/shared/ui/Toast.tsx
+++ b/src/shared/ui/Toast.tsx
@@ -7,6 +7,7 @@ import {
   useContext,
   ReactNode,
 } from "react";
+import { useLanguage } from "@/shared/ui/i18n";
 
 type ToastType = "success" | "error" | "info";
 
@@ -64,6 +65,8 @@ export function ToastContainer({
   toasts: ToastData[];
   removeToast: (id: number) => void;
 }) {
+  const { direction } = useLanguage();
+
   const styles: Record<ToastType, string> = {
     success: "bg-green-50 border-green-200 text-green-800",
     error: "bg-red-50 border-red-200 text-red-800",
@@ -71,7 +74,10 @@ export function ToastContainer({
   };
 
   return (
-    <div className="fixed bottom-4 left-4 z-50 flex flex-col gap-2" dir="ltr">
+    <div
+      className={`fixed bottom-4 ${direction === "rtl" ? "right-4" : "left-4"} z-50 flex flex-col gap-2`}
+      dir={direction}
+    >
       {toasts.map((t) => (
         <div
           key={t.id}


### PR DESCRIPTION
ToastContainer hardcoded `left-4` and `dir="ltr"`, so toasts always appeared bottom-left with LTR text even in Arabic/RTL mode. Read the direction from `useLanguage()` and switch positioning (`right-4` vs `left-4`) and the `dir` attribute accordingly.

Closes #276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Toast notifications now align with the active language direction, appearing on the right for right-to-left languages and on the left for left-to-right languages.

* **Tests**
  * Added coverage for toast positioning and text direction in Arabic and English locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->