### PR TITLE
fix: unify resource type lists to single shared constant

### DIFF
--- a/src/__tests__/DeveloperResourcesPage.test.tsx
+++ b/src/__tests__/DeveloperResourcesPage.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import { RESOURCE_TYPES } from '@/shared/constants/resource-types';
+import { LanguageProvider } from '@/shared/ui/i18n/LanguageContext';
+import DeveloperResourcesPage from '@/app/developer/resources/page';
+
+const mockUseDeveloperResources = vi.fn();
+vi.mock('@/hooks/useDeveloperResources', () => ({
+  useDeveloperResources: (...args: unknown[]) => mockUseDeveloperResources(...args),
+}));
+
+function renderWithProvider(ui: React.ReactElement) {
+  const result = render(<LanguageProvider>{ui}</LanguageProvider>);
+  act(() => {});
+  return result;
+}
+
+describe('DeveloperResourcesPage — type filter (src/app/developer/resources/page.tsx:10)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseDeveloperResources.mockReturnValue({ data: [], isLoading: false });
+    localStorage.setItem('ratq_locale', 'en');
+  });
+
+  it('renders All + 16 type options (17) with English labels', () => {
+    renderWithProvider(<DeveloperResourcesPage />);
+    expect(screen.getByRole('option', { name: 'All Types' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Recitation' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Tajweed' })).toBeInTheDocument();
+
+    const values = screen.getAllByRole('option').map((o) => (o as HTMLOptionElement).value);
+    expect(values).toContain(''); // All
+    for (const t of RESOURCE_TYPES) expect(values).toContain(t);
+  });
+
+  it('switches labels to Arabic when locale is ar', () => {
+    localStorage.setItem('ratq_locale', 'ar');
+    renderWithProvider(<DeveloperResourcesPage />);
+    expect(screen.getByRole('option', { name: 'كل الأنواع' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'تلاوة' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'تجويد' })).toBeInTheDocument();
+  });
+
+  it('keeps correct typing — selecting a CMS type updates filter', () => {
+    renderWithProvider(<DeveloperResourcesPage />);
+    const selects = screen.getAllByRole('combobox') as HTMLSelectElement[];
+    const typeSelect = selects[1]; // second select is type filter
+    fireEvent.change(typeSelect, { target: { value: 'mushaf' } });
+    expect(typeSelect.value).toBe('mushaf');
+  });
+
+  it('filters client-side: selecting mushaf hides other types', () => {
+    mockUseDeveloperResources.mockReturnValue({
+      data: [
+        {
+          id: 1,
+          name: 'Recitation A',
+          slug: 'rec-a',
+          type: 'recitation',
+          status: 'published',
+          total_downloads: 0,
+          license: 'MIT',
+          itqan_badge: false,
+        },
+        {
+          id: 2,
+          name: 'Library B',
+          slug: 'lib-b',
+          type: 'library',
+          status: 'published',
+          total_downloads: 0,
+          license: 'MIT',
+          itqan_badge: false,
+        },
+      ],
+      isLoading: false,
+    });
+    renderWithProvider(<DeveloperResourcesPage />);
+    expect(screen.getByText('Recitation A')).toBeInTheDocument();
+    expect(screen.getByText('Library B')).toBeInTheDocument();
+
+    const typeSelect = screen.getAllByRole('combobox')[1] as HTMLSelectElement;
+    fireEvent.change(typeSelect, { target: { value: 'recitation' } });
+
+    expect(screen.getByText('Recitation A')).toBeInTheDocument();
+    expect(screen.queryByText('Library B')).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/FilterPanel.test.tsx
+++ b/src/__tests__/FilterPanel.test.tsx
@@ -25,6 +25,27 @@ describe('FilterPanel', () => {
     mockSearchParams = new URLSearchParams();
   });
 
+  it('renders all 16 type filter buttons with translated labels (including CMS types)', () => {
+    renderWithProvider(<FilterPanel />);
+    expect(screen.getByRole('button', { name: 'Library' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Recitation' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Mushaf' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Tajweed' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Translation' })).toBeInTheDocument();
+    // 16 type buttons + license buttons
+    expect(
+      screen.getAllByRole('button', {
+        name: /Library|SDK|Dataset|API|Tafsir|Audio|PDF|JSON|Recitation|Mushaf|Program|Linguistic|Translation|Font|Search|Tajweed/,
+      }),
+    ).toHaveLength(16);
+  });
+
+  it('pushes a CMS type filter (e.g. recitation) onto the URL', () => {
+    renderWithProvider(<FilterPanel />);
+    fireEvent.click(screen.getByRole('button', { name: 'Recitation' }));
+    expect(mockPush).toHaveBeenCalledWith('/resources?type=recitation', { scroll: false });
+  });
+
   it('pushes a type filter onto the URL when a type is selected', () => {
     renderWithProvider(<FilterPanel />);
 

--- a/src/__tests__/ResourceForm.test.tsx
+++ b/src/__tests__/ResourceForm.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { RESOURCE_TYPES } from '@/shared/constants/resource-types';
+import { LanguageProvider } from '@/shared/ui/i18n/LanguageContext';
+import { ResourceForm } from '@/modules/developer/components/ResourceForm';
+
+function renderWithProvider(ui: React.ReactElement) {
+  const result = render(<LanguageProvider>{ui}</LanguageProvider>);
+  act(() => {});
+  return result;
+}
+
+describe('ResourceForm — type dropdown (src/modules/developer/components/ResourceForm.tsx:33)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.setItem('ratq_locale', 'en');
+  });
+
+  it('renders all 16 resource types as options from shared constant', () => {
+    renderWithProvider(<ResourceForm onSubmit={vi.fn()} />);
+    const options = screen.getAllByRole('option') as HTMLOptionElement[];
+    expect(options).toHaveLength(16);
+    expect(options.map((o) => o.value)).toEqual([...RESOURCE_TYPES]);
+  });
+
+  it('shows translated English labels for CMS types', () => {
+    renderWithProvider(<ResourceForm onSubmit={vi.fn()} />);
+    expect(screen.getByRole('option', { name: 'Recitation' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Mushaf' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Tajweed' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Translation' })).toBeInTheDocument();
+  });
+
+  it('preselects initial type even for CMS types like recitation', () => {
+    renderWithProvider(<ResourceForm onSubmit={vi.fn()} initial={{ type: 'recitation' }} />);
+    expect((screen.getByRole('combobox') as HTMLSelectElement).value).toBe('recitation');
+  });
+
+  it('preselects initial type for tajweed', () => {
+    renderWithProvider(<ResourceForm onSubmit={vi.fn()} initial={{ type: 'tajweed' }} />);
+    expect((screen.getByRole('combobox') as HTMLSelectElement).value).toBe('tajweed');
+  });
+
+  it('defaults to library when no initial type', () => {
+    renderWithProvider(<ResourceForm onSubmit={vi.fn()} />);
+    expect((screen.getByRole('combobox') as HTMLSelectElement).value).toBe('library');
+  });
+
+  it('switches labels to Arabic when locale is ar', () => {
+    localStorage.clear();
+    localStorage.setItem('ratq_locale', 'ar');
+    // LanguageProvider defaults to 'ar', so no async switch needed
+    const result = render(
+      <LanguageProvider>
+        <ResourceForm onSubmit={vi.fn()} />
+      </LanguageProvider>,
+    );
+    act(() => {});
+    expect(screen.getByRole('option', { name: 'تلاوة' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'تجويد' })).toBeInTheDocument();
+    result.unmount();
+  });
+});

--- a/src/__tests__/resource-types.test.ts
+++ b/src/__tests__/resource-types.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { RESOURCE_TYPES } from '@/shared/constants/resource-types';
+import type { ResourceType } from '@/types/resource';
+
+describe('RESOURCE_TYPES constant — single source of truth', () => {
+  it('contains all 16 ResourceType values in canonical order', () => {
+    const expected: ResourceType[] = [
+      'library',
+      'sdk',
+      'dataset',
+      'api',
+      'tafsir',
+      'audio',
+      'pdf',
+      'json',
+      'recitation',
+      'mushaf',
+      'program',
+      'linguistic',
+      'translation',
+      'font',
+      'search',
+      'tajweed',
+    ];
+    expect(RESOURCE_TYPES).toEqual(expected);
+  });
+
+  it('has length 16 and no duplicates', () => {
+    expect(RESOURCE_TYPES).toHaveLength(16);
+    expect(new Set(RESOURCE_TYPES).size).toBe(16);
+  });
+
+  it('is assignable to ResourceType[] (type-level sanity)', () => {
+    // If RESOURCE_TYPES drifts from the union, this line fails to compile
+    const asTypes: ResourceType[] = [...RESOURCE_TYPES];
+    expect(asTypes).toHaveLength(16);
+  });
+});

--- a/src/app/developer/resources/page.tsx
+++ b/src/app/developer/resources/page.tsx
@@ -3,25 +3,21 @@
 import { useState } from 'react';
 import { useDeveloperResources } from '@/hooks/useDeveloperResources';
 import { ResourceTable } from '@/modules/developer/components/ResourceTable';
-import type { Resource } from '@/types/resource';
-
-const typeFilters: { value: string; label: string }[] = [
-  { value: '', label: 'الكل' },
-  { value: 'library', label: 'مكتبة' },
-  { value: 'sdk', label: 'SDK' },
-  { value: 'api', label: 'API' },
-  { value: 'dataset', label: 'بيانات' },
-  { value: 'tafsir', label: 'تفسير' },
-  { value: 'audio', label: 'صوت' },
-  { value: 'pdf', label: 'PDF' },
-  { value: 'json', label: 'JSON' },
-];
+import type { Resource, ResourceType } from '@/types/resource';
+import { RESOURCE_TYPES } from '@/shared/constants/resource-types';
+import { useLanguage } from '@/shared/ui/i18n';
 
 export default function DeveloperResourcesPage() {
+  const { t } = useLanguage();
   const { data: resources, isLoading } = useDeveloperResources();
   const [statusFilter, setStatusFilter] = useState<string>('');
-  const [typeFilter, setTypeFilter] = useState<string>('');
+  const [typeFilter, setTypeFilter] = useState<ResourceType | ''>('');
   const [searchQuery, setSearchQuery] = useState('');
+
+  const typeFilters: { value: ResourceType | ''; label: string }[] = [
+    { value: '', label: t.catalog.filters.allTypes },
+    ...RESOURCE_TYPES.map((value) => ({ value, label: t.catalog.types[value] })),
+  ];
 
   if (isLoading) {
     return (
@@ -73,11 +69,11 @@ export default function DeveloperResourcesPage() {
         </select>
         <select
           value={typeFilter}
-          onChange={(e) => setTypeFilter(e.target.value)}
+          onChange={(e) => setTypeFilter(e.target.value as ResourceType | '')}
           className="input-field text-sm py-2 px-3"
         >
           {typeFilters.map((f) => (
-            <option key={f.value} value={f.value}>{f.label}</option>
+            <option key={f.value || 'all'} value={f.value}>{f.label}</option>
           ))}
         </select>
       </div>

--- a/src/modules/developer/components/ResourceForm.tsx
+++ b/src/modules/developer/components/ResourceForm.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useTranslations } from '@/shared/ui/i18n';
 import { Slug } from '@/modules/resources/domain/value-objects/slug';
 import type { ResourceType } from '@/types/resource';
+import { RESOURCE_TYPES } from '@/shared/constants/resource-types';
 import { uploadMedia } from '@/modules/developer/infrastructure/resources-api';
 
 interface ResourceFormProps {
@@ -70,13 +71,10 @@ export function ResourceForm({ onSubmit, initial, submitLabel }: ResourceFormPro
     onSubmit({ name, type, short_description: shortDescription, image, description, license, github_url, documentation_url });
   };
 
-  const resourceTypes: { value: ResourceType; label: string }[] = [
-    { value: 'library', label: t.catalog.types.library },
-    { value: 'sdk', label: t.catalog.types.sdk },
-    { value: 'dataset', label: t.catalog.types.dataset },
-    { value: 'api', label: t.catalog.types.api },
-    { value: 'tafsir', label: t.catalog.types.tafsir },
-  ];
+  const resourceTypes: { value: ResourceType; label: string }[] = RESOURCE_TYPES.map((value) => ({
+    value,
+    label: t.catalog.types[value],
+  }));
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4 text-start">

--- a/src/modules/resources/components/FilterPanel.tsx
+++ b/src/modules/resources/components/FilterPanel.tsx
@@ -2,14 +2,7 @@
 
 import { useRouter, usePathname, useSearchParams } from 'next/navigation';
 import { useLanguage } from '@/shared/ui/i18n';
-import type { ResourceType } from '@/types/resource';
-
-// Static list matching the ResourceType union in src/types/resource.ts.
-// Kept here (not imported) since ResourceType is a type, not a runtime value.
-const RESOURCE_TYPES: ResourceType[] = [
-  'library', 'sdk', 'dataset', 'api', 'tafsir', 'audio', 'pdf', 'json',
-  'recitation', 'mushaf', 'program', 'linguistic', 'translation', 'font', 'search', 'tajweed',
-];
+import { RESOURCE_TYPES } from '@/shared/constants/resource-types';
 
 // Free-form strings from resource data (not an enum in src/types/resource.ts).
 // Sourced from observed values across mock-data.ts / cms.ts / payload.ts.

--- a/src/shared/constants/resource-types.ts
+++ b/src/shared/constants/resource-types.ts
@@ -1,0 +1,24 @@
+import type { ResourceType } from '@/types/resource';
+
+/**
+ * Single source of truth for the runtime list of resource types.
+ * Must stay in sync with the `ResourceType` union in `src/types/resource.ts`.
+ */
+export const RESOURCE_TYPES: readonly ResourceType[] = [
+  'library',
+  'sdk',
+  'dataset',
+  'api',
+  'tafsir',
+  'audio',
+  'pdf',
+  'json',
+  'recitation',
+  'mushaf',
+  'program',
+  'linguistic',
+  'translation',
+  'font',
+  'search',
+  'tajweed',
+] as const;


### PR DESCRIPTION
## Summary

Unifies all resource type lists under the shared `RESOURCE_TYPES` constant (16 values).

Previously:

* `FilterPanel`: 16 types
* `ResourceForm`: 5 types
* Developer resources filter: 9 types

This caused resource types such as `recitation`, `mushaf`, `tajweed`, etc. to be unavailable in some parts of the application, and the developer filter used hard-coded Arabic labels.

Now, all three consumers use the shared `RESOURCE_TYPES` constant with localized labels from `t.catalog.types`.

## Changes

* Added `src/shared/constants/resource-types.ts` as the single source of truth for all 16 `ResourceType` values.
* Updated `FilterPanel` to use the shared constant instead of its local copy.
* Updated `ResourceForm` to support all 16 resource types and localized labels.
* Updated the developer resources filter to:

  * Support all 16 resource types.
  * Use `ResourceType | ''` for type-safe filtering.
  * Use localized `All Types` labels.
  * Support both English and Arabic correctly.

## Testing

Added and updated tests by responsibility:

* `resource-types.test.ts` — validates the shared constant.
* `FilterPanel.test.tsx` — validates all 16 filter types.
* `ResourceForm.test.tsx` — validates all options, localization, and type preselection.
* `DeveloperResourcesPage.test.tsx` — validates all 16 types, localization, and filtering.

Closes #278 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent resource type filtering across developer resources, resource forms, and filter panels.
  * Added Arabic translations for resource type labels and improved locale-aware filtering.

* **Security**
  * Added transport security, referrer policy, and content security reporting headers.

* **Configuration**
  * Database passwords can now be supplied through environment variables instead of relying on a hardcoded value.

* **Quality**
  * Expanded automated coverage for resource type options, filtering, translations, and form behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->